### PR TITLE
feat: implement assert_execution_result with custom diff fn

### DIFF
--- a/tests/common/diff.rs
+++ b/tests/common/diff.rs
@@ -1,0 +1,225 @@
+use alloy_consensus::{Eip658Value, Receipt};
+use alloy_primitives::{Log, B256, U256};
+use pevm::PevmTxExecutionResult;
+use revm::primitives::{Account, AccountInfo, AccountStatus, Bytecode, EvmStorageSlot};
+use std::{
+    collections::BTreeSet,
+    fmt::{Debug, Display},
+    hash::Hash,
+    path::PathBuf,
+};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Reason {
+    path: PathBuf,
+    left: String,
+    right: String,
+}
+
+impl Reason {
+    fn new(path: PathBuf, left: impl Debug, right: impl Debug) -> Self {
+        Reason {
+            path,
+            left: format!("{:?}", left),
+            right: format!("{:?}", right),
+        }
+    }
+}
+
+impl Display for Reason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let path_components: Vec<&str> = self.path.iter().map(|s| s.to_str().unwrap()).collect();
+
+        write!(
+            f,
+            "_.{}\n   left = {}\n  right = {}",
+            path_components.join("."),
+            self.left,
+            self.right
+        )
+    }
+}
+
+fn diff_simple<T: PartialEq + Debug>(path: PathBuf, left: &T, right: &T) -> Vec<Reason> {
+    if left != right {
+        Vec::from(&[Reason::new(path, left, right)])
+    } else {
+        Vec::new()
+    }
+}
+
+pub trait Diffable {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason>;
+}
+
+macro_rules! impl_diffable {
+    ($t:ty) => {
+        impl Diffable for $t {
+            fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+                diff_simple(path, left, right)
+            }
+        }
+    };
+}
+
+impl_diffable!(AccountStatus);
+impl_diffable!(B256);
+impl_diffable!(Bytecode);
+impl_diffable!(Eip658Value);
+impl_diffable!(EvmStorageSlot);
+impl_diffable!(Log);
+impl_diffable!(u128);
+impl_diffable!(U256);
+impl_diffable!(u64);
+impl_diffable!(usize);
+
+impl<T: Diffable> Diffable for Option<T> {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        match (left, right) {
+            (None, None) => Vec::new(),
+            (None, Some(_)) => Vec::from(&[Reason::new(path, "None", "Some(_)")]),
+            (Some(_), None) => Vec::from(&[Reason::new(path, "Some(_)", "None")]),
+            (Some(left_inner), Some(right_inner)) => {
+                Diffable::diff(path.join("unwrap()"), left_inner, right_inner)
+            }
+        }
+    }
+}
+
+impl<T: Diffable, E: Debug + PartialEq> Diffable for Result<T, E> {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        match (left, right) {
+            (Ok(left_inner), Ok(right_inner)) => {
+                Diffable::diff(path.join("unwrap()"), left_inner, right_inner)
+            }
+            (Ok(_), Err(_)) => Vec::from(&[Reason::new(path, "Ok(_)", "Err(_)")]),
+            (Err(_), Ok(_)) => Vec::from(&[Reason::new(path, "Err(_)", "Ok(_)")]),
+            (Err(left_error), Err(right_error)) => {
+                diff_simple(path.join("unwrap_err()"), left_error, right_error)
+            }
+        }
+    }
+}
+
+impl<T: Diffable> Diffable for [T] {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = diff_simple(path.join("len()"), &left.len(), &right.len());
+        for (index, (left_item, right_item)) in Iterator::zip(left.iter(), right.iter()).enumerate()
+        {
+            reasons.extend(Diffable::diff(
+                path.join(index.to_string()),
+                left_item,
+                right_item,
+            ));
+        }
+        reasons
+    }
+}
+
+impl<T: Diffable> Diffable for Vec<T> {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        Diffable::diff(path, &left[..], &right[..])
+    }
+}
+
+impl Diffable for AccountInfo {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = Vec::new();
+        reasons.extend(Diffable::diff(
+            path.join("balance"),
+            &left.balance,
+            &right.balance,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("nonce"), //
+            &left.nonce,
+            &right.nonce,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("code_hash"),
+            &left.code_hash,
+            &right.code_hash,
+        ));
+        reasons
+    }
+}
+
+impl Diffable for Receipt {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = Vec::new();
+        reasons.extend(Diffable::diff(
+            path.join("status"),
+            &left.status,
+            &right.status,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("cumulative_gas_used"),
+            &left.cumulative_gas_used,
+            &right.cumulative_gas_used,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("logs"),
+            &left.logs[..],
+            &right.logs[..],
+        ));
+        reasons
+    }
+}
+
+impl<K: Copy + Ord + Debug + Hash, V: Diffable + Clone> Diffable
+    for std::collections::HashMap<K, V>
+{
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = Vec::new();
+        let all_addresses: BTreeSet<K> = Iterator::chain(left.keys(), right.keys())
+            .copied()
+            .collect();
+        for key in all_addresses {
+            reasons.extend(Diffable::diff(
+                path.join(format!("get(\"{:?}\")", key)),
+                &left.get(&key).cloned(),
+                &right.get(&key).cloned(),
+            ));
+        }
+        reasons
+    }
+}
+
+impl Diffable for Account {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = Vec::new();
+        reasons.extend(Diffable::diff(
+            path.join("info"), //
+            &left.info,
+            &right.info,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("storage"),
+            &left.storage,
+            &right.storage,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("status"),
+            &left.status,
+            &right.status,
+        ));
+        reasons
+    }
+}
+
+impl Diffable for PevmTxExecutionResult {
+    fn diff(path: PathBuf, left: &Self, right: &Self) -> Vec<Reason> {
+        let mut reasons = Vec::new();
+        reasons.extend(Diffable::diff(
+            path.join("receipt"),
+            &left.receipt,
+            &right.receipt,
+        ));
+        reasons.extend(Diffable::diff(
+            path.join("state"),
+            &left.state,
+            &right.state,
+        ));
+        reasons
+    }
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,6 +12,7 @@ use revm::{db::PlainAccount, primitives::KECCAK_EMPTY};
 
 pub mod runner;
 pub use runner::{assert_execution_result, mock_account, test_execute_alloy, test_execute_revm};
+pub mod diff;
 pub mod storage;
 
 pub type ChainState = AHashMap<Address, PlainAccount>;

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -1,3 +1,4 @@
+use super::diff::Diffable;
 use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Bloom, B256};
 use alloy_provider::network::eip2718::Encodable2718;
@@ -21,8 +22,22 @@ pub fn mock_account(idx: usize) -> (Address, PlainAccount) {
     )
 }
 
-pub fn assert_execution_result(sequential_result: &PevmResult, parallel_result: &PevmResult) {
-    assert_eq!(sequential_result, parallel_result);
+pub fn assert_execution_result(left: &PevmResult, right: &PevmResult) {
+    let reasons = Diffable::diff("".into(), left, right);
+    if !reasons.is_empty() {
+        panic!(
+            "{}\n{}",
+            "assertion `left == right` failed",
+            reasons
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    } else {
+        // defensive programming: just in case we implement Diffable::diff incorrectly
+        assert_eq!(left, right);
+    }
 }
 
 // Execute an REVM block sequentially & with PEVM and assert that


### PR DESCRIPTION
## Before

```
thread 'main' panicked at tests/common/runner.rs:25:5:
assertion `left == right` failed
  left: Ok([PevmTxExecutionResult { receipt: Receipt { status: Eip658(true), cumulative_gas_used: 21793, logs: [Log { address: 0xaa0bb10cec1fa372eb3abc17c933fc6ba863dd9e, data: LogData { topics: [0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef, 0x0000000000000000000000006f3864d5abec0a2f72c906f373a2fcbc35fd7ac1, 0x0000000000000000000000004516f566bd083a74ebd6a1ce9944843506817289], data: 0x0000000000000000000000000000000000000000000000008ac7230489e80000 } }] }, state: {0x6f3864d5abec0a2f72c906f373a2fcbc35fd7ac1: Account { info: AccountInfo { balance: 96469000000000, previous_or_original_balance: 118262000000000, nonce: 2, previous_or_original_nonce: 1, code_hash: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, previous_or_original_code_hash: 0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470, code: Some(LegacyRaw(0x)) }, storage: {}, status: AccountStatus(Touched) }, 0xaa0bb10cec1fa372eb3abc17c933fc6ba863dd9e: Account { info: AccountInfo { balance: 100010000000000, previous_or_original_balance: 100010000000000, nonce: 1, previous_or_original_nonce: 1, code_hash: 0x2962bbe07320477b22e94d413c9220e1d02b34a0a12ce73105790cf3575b582d, previous_or_original_code_hash: 0x2962bbe07320477b22e94d413c9220e1d02b34a0a12ce73105790cf3575b582d, code: 

(...very long text)
```

## After

```
thread 'main' panicked at tests/common/runner.rs:28:9:
_.unwrap().92.state.get("0x06012c8cf97bead5deae237070f9587f8e7a266d").unwrap().info.balance
   left = 190628230317090082461
  right = 190620230317090082461
_.unwrap().93.state.get("0x06012c8cf97bead5deae237070f9587f8e7a266d").unwrap().info.balance
   left = 190628230317090082461
  right = 190620230317090082461
_.unwrap().110.state.get("0x06012c8cf97bead5deae237070f9587f8e7a266d").unwrap().info.balance
   left = 190628230317090082461
  right = 190620230317090082461
_.unwrap().118.state.get("0x06012c8cf97bead5deae237070f9587f8e7a266d").unwrap().info.balance
   left = 190628230317090082461
  right = 190620230317090082461
_.unwrap().125.state.get("0x06012c8cf97bead5deae237070f9587f8e7a266d").unwrap().info.balance
   left = 190636230317090082461
  right = 190628230317090082461
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```