### PR TITLE
chore: fix typo in comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,16 +77,16 @@ type TransactionsStatus = Vec<TxIncarnationStatus>;
 // We use `Vec` for dependents to simplify runtime update code.
 // We use `HashMap` for dependencies as we're only adding
 // them during preprocessing and removing them during processing.
-// The undelrying `HashSet` is to simplify index deduplication logic
+// The underlying `HashSet` is to simplify index deduplication logic
 // while adding new dependencies.
-// TODO: Intuitively both should share a smiliar data structure?
+// TODO: Intuitively both should share a similar data structure?
 type TransactionsDependents = Vec<Vec<TxIdx>>;
 type TransactionsDependencies = AHashMap<TxIdx, Vec<TxIdx>>;
 
 // BlockSTM maintains an in-memory multi-version data structure that
 // stores for each memory location the latest value written per
 // transaction, along with the associated transaction version. When a
-// transaciton reads a memory location, it obtains from the
+// transaction reads a memory location, it obtains from the
 // multi-version data structure the value written to this location by
 // the highest transaction that appears before it in the block, along
 // with the associated version. For instance, tx5 would read the value
@@ -128,7 +128,7 @@ pub enum ReadError {
 // vectors are noticeably faster in the mainnet benchmark.
 struct ReadSet {
     common: Vec<(MemoryLocation, ReadOrigin)>,
-    // An explicity beneficiary read may read from multiple lazily
+    // An explicit beneficiary read may read from multiple lazily
     // updated values. A micro-optimization here is to have a
     // read origin with only an incarnation index instead of a
     // while transaction version, as the latter is consecutive

--- a/src/mv_memory.rs
+++ b/src/mv_memory.rs
@@ -176,7 +176,7 @@ impl MvMemory {
     // for reading speculatively, that no transaction between the highest
     // transaction found and the input transaction writes to the same memory
     // location.
-    // If the entry corresponding to the highest transaction index is an ESTIMTE
+    // If the entry corresponding to the highest transaction index is an ESTIMATE
     // marker, we return an error to tell the caller to postpone the execution of
     // the input transaction until the next incarnation of this highest blocking
     // index transaction completes, since it is expected to write to the ESTIMATE

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -85,7 +85,7 @@ pub fn execute_revm<S: Storage + Send + Sync>(
     concurrency_level: NonZeroUsize,
 ) -> PevmResult {
     if txs.is_empty() {
-        return PevmResult::Ok(Vec::new());
+        return Ok(Vec::new());
     }
 
     let beneficiary_address = block_env.coinbase;

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -59,7 +59,7 @@ use crate::{
 pub(crate) struct Scheduler {
     /// The next transaction to try and execute.
     execution_idx: CachePadded<AtomicUsize>,
-    /// The next tranasction to try and validate.
+    /// The next transaction to try and validate.
     validation_idx: CachePadded<AtomicUsize>,
     /// The most up-to-date incarnation number (initially 0) and
     /// the status of this incarnation.
@@ -73,7 +73,7 @@ pub(crate) struct Scheduler {
     num_active_tasks: AtomicUsize,
     /// Number of times a task index was decreased.
     decrease_cnt: AtomicUsize,
-    /// The list of dependent transactions to resumne when the
+    /// The list of dependent transactions to resume when the
     /// key transaction is re-executed.
     transactions_dependents: Vec<Mutex<Vec<TxIdx>>>,
     /// A list of optional dependencies flagged during preprocessing.
@@ -222,12 +222,12 @@ impl Scheduler {
 
     // Add `tx_idx` as a dependent of `blocking_tx_idx` so `tx_idx` is
     // re-executed when the next `blocking_tx_idx` incarnation is executed.
-    // Return `false` if we encouter a race condition when `blocking_tx_idx`
+    // Return `false` if we encounter a race condition when `blocking_tx_idx`
     // gets re-executed before the dependency can be added.
     // TODO: Better error handling, including asserting that both indices are in range.
     pub(crate) fn add_dependency(&self, tx_idx: TxIdx, blocking_tx_idx: TxIdx) -> bool {
         // This is an important lock to prevent a race condition where the blocking
-        // transaction completes re-execution before this dependecy can be added.
+        // transaction completes re-execution before this dependency can be added.
         let blocking_transaction_status = index_mutex!(self.transactions_status, blocking_tx_idx);
         if let TxIncarnationStatus::Executed(_) = *blocking_transaction_status {
             return false;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -95,7 +95,7 @@ impl From<AccountInfo> for AccountBasic {
 /// An interface to provide chain state to BlockSTM for transaction execution.
 /// Staying close to the underlying REVM's Database trait while not leaking
 /// its primitives to library users (favoring Alloy at the moment).
-/// TODO: Better API for third-pary integration.
+/// TODO: Better API for third-party integration.
 pub trait Storage {
     /// Errors when querying data from storage.
     type Error: Debug;

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -247,7 +247,7 @@ impl<S: Storage> Database for VmDb<S> {
     fn basic(
         &mut self,
         address: Address,
-        // TODO: Better way for REVM to notifiy explicit reads
+        // TODO: Better way for REVM to notify explicit reads
         is_preload: bool,
     ) -> Result<Option<AccountInfo>, Self::Error> {
         // We preload a mock beneficiary account, to only lazy evaluate it on
@@ -336,8 +336,8 @@ impl<S: Storage> Vm<S> {
     // An execution may observe a read dependency on a lower transaction. This happens
     // when the last incarnation of the dependency wrote to a memory location that
     // this transaction reads, but it aborted before the read. In this case, the
-    // depedency index is returend via `blocking_tx_idx`. An execution task for this
-    // this transaction is re-scheduled after the blocking dependency finishes its
+    // dependency index is returned via `blocking_tx_idx`. An execution task for this
+    // transaction is re-scheduled after the blocking dependency finishes its
     // next incarnation.
     //
     // When a transaction attempts to write a value to a location, the location and

--- a/tests/small_blocks.rs
+++ b/tests/small_blocks.rs
@@ -1,4 +1,4 @@
-// Test small blocks that we have specific handling for, like implicity fine-tuning
+// Test small blocks that we have specific handling for, like implicit fine-tuning
 // the concurrency level, falling back to sequential processing, etc.
 
 use alloy_primitives::{Address, U256};


### PR DESCRIPTION
When I read the code of pevm, I found some typo. So I'd like to fix them.