### PR TITLE
refactor: use Chain to set chain_id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,11 +47,12 @@ checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.18"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03fd095a9d70f4b1c5c102c84a4c782867a5c6416dbf6dcd42a63e7c7a89d3c8"
+checksum = "04e9a1892803b02f53e25bea3e414ddd0501f12d97456c9d5ade4edf88f9516f"
 dependencies = [
  "num_enum",
+ "serde",
  "strum",
 ]
 
@@ -2500,6 +2501,7 @@ name = "pevm"
 version = "0.1.0"
 dependencies = [
  "ahash",
+ "alloy-chains",
  "alloy-consensus",
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 # that need more security guarantees even for internally hashing
 # EVM memory locations (we do not persist these hashes).
 ahash = "0.8.11"
+alloy-chains = { version = "0.1.22", features = ["serde"] }
 alloy-primitives = { version = "0.7.5", features = ["asm-keccak"] }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
 bitvec = "1.0.1"
@@ -28,7 +29,6 @@ alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
 reqwest = "0.12.4"
 tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
-alloy-chains = { version = "0.1.22", features = ["serde"] }
 
 [dev-dependencies]
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ alloy-transport = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
 reqwest = "0.12.4"
 tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
+alloy-chains = { version = "0.1.22", features = ["serde"] }
 
 [dev-dependencies]
 alloy-consensus = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # that need more security guarantees even for internally hashing
 # EVM memory locations (we do not persist these hashes).
 ahash = "0.8.11"
-alloy-chains = { version = "0.1.22", features = ["serde"] }
+alloy-chains = { version = "0.1.22" }
 alloy-primitives = { version = "0.7.5", features = ["asm-keccak"] }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
 bitvec = "1.0.1"

--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -7,6 +7,7 @@
 use std::{num::NonZeroUsize, thread};
 
 use ahash::AHashMap;
+use alloy_chains::Chain;
 use alloy_primitives::{Address, U160, U256};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pevm::{execute_revm, execute_revm_sequential, InMemoryStorage};
@@ -32,6 +33,7 @@ static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 pub fn bench(c: &mut Criterion, name: &str, state: common::ChainState, txs: Vec<TxEnv>) {
     let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
+    let chain = Chain::mainnet();
     let spec_id = SpecId::LATEST;
     let block_env = BlockEnv::default();
     let storage = InMemoryStorage::new(state, []);
@@ -40,6 +42,7 @@ pub fn bench(c: &mut Criterion, name: &str, state: common::ChainState, txs: Vec<
         b.iter(|| {
             execute_revm_sequential(
                 black_box(storage.clone()),
+                black_box(chain),
                 black_box(spec_id),
                 black_box(block_env.clone()),
                 black_box(txs.clone()),
@@ -50,6 +53,7 @@ pub fn bench(c: &mut Criterion, name: &str, state: common::ChainState, txs: Vec<
         b.iter(|| {
             execute_revm(
                 black_box(storage.clone()),
+                black_box(chain),
                 black_box(spec_id),
                 black_box(block_env.clone()),
                 black_box(txs.clone()),

--- a/benches/mainnet.rs
+++ b/benches/mainnet.rs
@@ -6,6 +6,7 @@
 
 use std::{num::NonZeroUsize, thread};
 
+use alloy_chains::Chain;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 
 // Better project structure
@@ -16,6 +17,7 @@ pub mod common;
 static GLOBAL: snmalloc_rs::SnMalloc = snmalloc_rs::SnMalloc;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
+    let chain = Chain::mainnet();
     let concurrency_level = thread::available_parallelism()
         .unwrap_or(NonZeroUsize::MIN)
         // 8 seems to be the sweet max for Ethereum blocks. Any more
@@ -34,6 +36,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 pevm::execute(
                     black_box(storage.clone()),
+                    black_box(chain),
                     black_box(block.clone()),
                     black_box(concurrency_level),
                     black_box(true),
@@ -44,6 +47,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             b.iter(|| {
                 pevm::execute(
                     black_box(storage.clone()),
+                    black_box(chain),
                     black_box(block.clone()),
                     black_box(concurrency_level),
                     black_box(false),

--- a/tests/beneficiary.rs
+++ b/tests/beneficiary.rs
@@ -1,12 +1,9 @@
 // Tests for the beneficiary account, especially for the lazy update of its balance to avoid
 // "implicit" dependency among consecutive transactions.
 
-use alloy_chains::Chain;
 use pevm::InMemoryStorage;
 use rand::random;
-use revm::primitives::{
-    alloy_primitives::U160, env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256,
-};
+use revm::primitives::{alloy_primitives::U160, env::TxEnv, Address, TransactTo, U256};
 
 pub mod common;
 
@@ -16,9 +13,6 @@ fn test_beneficiary(get_address: fn(usize) -> Address) {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `BLOCK_SIZE` user accounts.
         InMemoryStorage::new((0..=BLOCK_SIZE).map(common::mock_account), []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
         // Mock `BLOCK_SIZE` transactions sending some tokens to itself.
         // Skipping `Address::ZERO` as the beneficiary account.
         (1..=BLOCK_SIZE)

--- a/tests/beneficiary.rs
+++ b/tests/beneficiary.rs
@@ -1,6 +1,7 @@
 // Tests for the beneficiary account, especially for the lazy update of its balance to avoid
 // "implicit" dependency among consecutive transactions.
 
+use alloy_chains::Chain;
 use pevm::InMemoryStorage;
 use rand::random;
 use revm::primitives::{
@@ -15,6 +16,7 @@ fn test_beneficiary(get_address: fn(usize) -> Address) {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `BLOCK_SIZE` user accounts.
         InMemoryStorage::new((0..=BLOCK_SIZE).map(common::mock_account), []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         // Mock `BLOCK_SIZE` transactions sending some tokens to itself.

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -1,3 +1,4 @@
+use alloy_chains::Chain;
 use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Bloom, B256};
 use alloy_provider::network::eip2718::Encodable2718;
@@ -29,14 +30,21 @@ pub fn assert_execution_result(sequential_result: &PevmResult, parallel_result: 
 // the execution results match.
 pub fn test_execute_revm<S: Storage + Clone + Send + Sync>(
     storage: S,
+    chain: Chain,
     spec_id: SpecId,
     block_env: BlockEnv,
     txs: Vec<TxEnv>,
 ) {
     let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
     assert_execution_result(
-        &pevm::execute_revm_sequential(storage.clone(), spec_id, block_env.clone(), txs.clone()),
-        &pevm::execute_revm(storage, spec_id, block_env, txs, concurrency_level),
+        &pevm::execute_revm_sequential(
+            storage.clone(),
+            chain,
+            spec_id,
+            block_env.clone(),
+            txs.clone(),
+        ),
+        &pevm::execute_revm(storage, chain, spec_id, block_env, txs, concurrency_level),
     );
 }
 
@@ -84,12 +92,19 @@ fn calculate_receipt_root(
 // the execution results match.
 pub fn test_execute_alloy<S: Storage + Clone + Send + Sync>(
     storage: S,
+    chain: Chain,
     block: Block,
     must_match_block_header: bool,
 ) {
     let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
-    let sequential_result = pevm::execute(storage.clone(), block.clone(), concurrency_level, true);
-    let parallel_result = pevm::execute(storage, block.clone(), concurrency_level, false);
+    let sequential_result = pevm::execute(
+        storage.clone(),
+        chain,
+        block.clone(),
+        concurrency_level,
+        true,
+    );
+    let parallel_result = pevm::execute(storage, chain, block.clone(), concurrency_level, false);
     assert_execution_result(&sequential_result, &parallel_result);
 
     if must_match_block_header {

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -28,23 +28,24 @@ pub fn assert_execution_result(sequential_result: &PevmResult, parallel_result: 
 
 // Execute an REVM block sequentially & with PEVM and assert that
 // the execution results match.
-pub fn test_execute_revm<S: Storage + Clone + Send + Sync>(
-    storage: S,
-    chain: Chain,
-    spec_id: SpecId,
-    block_env: BlockEnv,
-    txs: Vec<TxEnv>,
-) {
+pub fn test_execute_revm<S: Storage + Clone + Send + Sync>(storage: S, txs: Vec<TxEnv>) {
     let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
     assert_execution_result(
         &pevm::execute_revm_sequential(
             storage.clone(),
-            chain,
-            spec_id,
-            block_env.clone(),
+            Chain::mainnet(),
+            SpecId::LATEST,
+            BlockEnv::default(),
             txs.clone(),
         ),
-        &pevm::execute_revm(storage, chain, spec_id, block_env, txs, concurrency_level),
+        &pevm::execute_revm(
+            storage,
+            Chain::mainnet(),
+            SpecId::LATEST,
+            BlockEnv::default(),
+            txs,
+            concurrency_level,
+        ),
     );
 }
 

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -9,13 +9,12 @@ pub mod common;
 pub mod erc20;
 
 use ahash::AHashMap;
-use alloy_chains::Chain;
 use common::test_execute_revm;
 use erc20::generate_cluster;
 use pevm::InMemoryStorage;
 use revm::{
     db::PlainAccount,
-    primitives::{Address, BlockEnv, SpecId, TxEnv},
+    primitives::{Address, TxEnv},
 };
 
 #[test]
@@ -23,13 +22,7 @@ fn erc20_independent() {
     const N: usize = 37123;
     let (mut state, txs) = generate_cluster(N, 1, 1);
     state.insert(Address::ZERO, PlainAccount::default()); // Beneficiary
-    test_execute_revm(
-        InMemoryStorage::new(state, []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
-        txs,
-    );
+    test_execute_revm(InMemoryStorage::new(state, []), txs);
 }
 
 #[test]
@@ -50,11 +43,5 @@ fn erc20_clusters() {
         final_state.extend(state);
         final_txs.extend(txs);
     }
-    common::test_execute_revm(
-        InMemoryStorage::new(final_state, []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
-        final_txs,
-    )
+    common::test_execute_revm(InMemoryStorage::new(final_state, []), final_txs)
 }

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -9,6 +9,7 @@ pub mod common;
 pub mod erc20;
 
 use ahash::AHashMap;
+use alloy_chains::Chain;
 use common::test_execute_revm;
 use erc20::generate_cluster;
 use pevm::InMemoryStorage;
@@ -24,6 +25,7 @@ fn erc20_independent() {
     state.insert(Address::ZERO, PlainAccount::default()); // Beneficiary
     test_execute_revm(
         InMemoryStorage::new(state, []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         txs,
@@ -50,6 +52,7 @@ fn erc20_clusters() {
     }
     common::test_execute_revm(
         InMemoryStorage::new(final_state, []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         final_txs,

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -108,8 +108,6 @@ fn run_test_unit(path: &Path, unit: &TestUnit) {
         if *spec_name == SpecName::Constantinople {
             return;
         }
-        let spec_id = spec_name.to_spec_id();
-        let chain = Chain::mainnet();
 
         tests.par_iter().for_each(|test| {
             let tx_env = build_tx_env(&unit.transaction, &test.indexes);
@@ -135,8 +133,8 @@ fn run_test_unit(path: &Path, unit: &TestUnit) {
                 test.expect_exception.as_deref(),
                 pevm::execute_revm(
                     InMemoryStorage::new(chain_state.clone(), []),
-                    chain,
-                    spec_id,
+                    Chain::mainnet(),
+                    spec_name.to_spec_id(),
                     build_block_env(&unit.env),
                     vec![tx_env.unwrap()],
                     NonZeroUsize::MIN,

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -9,6 +9,7 @@
 // - Help outline the minimal state commitment logic for PEVM.
 
 use ahash::AHashMap;
+use alloy_chains::Chain;
 use pevm::{InMemoryStorage, PevmError, PevmTxExecutionResult};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use revm::db::PlainAccount;
@@ -108,6 +109,7 @@ fn run_test_unit(path: &Path, unit: &TestUnit) {
             return;
         }
         let spec_id = spec_name.to_spec_id();
+        let chain = Chain::mainnet();
 
         tests.par_iter().for_each(|test| {
             let tx_env = build_tx_env(&unit.transaction, &test.indexes);
@@ -133,6 +135,7 @@ fn run_test_unit(path: &Path, unit: &TestUnit) {
                 test.expect_exception.as_deref(),
                 pevm::execute_revm(
                     InMemoryStorage::new(chain_state.clone(), []),
+                    chain,
                     spec_id,
                     build_block_env(&unit.env),
                     vec![tx_env.unwrap()],

--- a/tests/mainnet.rs
+++ b/tests/mainnet.rs
@@ -6,6 +6,7 @@ use std::{
     fs::{self, File},
 };
 
+use alloy_chains::Chain;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::{BlockId, BlockTransactionsKind};
@@ -51,7 +52,7 @@ fn mainnet_blocks_from_rpc() {
         let spec_id = pevm::get_block_spec(&block.header).unwrap();
         let rpc_storage = RpcStorage::new(provider, spec_id, BlockId::number(block_number - 1));
         let db = CacheDB::new(&rpc_storage);
-        common::test_execute_alloy(db.clone(), block.clone(), true);
+        common::test_execute_alloy(db.clone(), Chain::mainnet(), block.clone(), true);
 
         // Snapshot blocks (for benchmark)
         // TODO: Port to a dedicated CLI instead?
@@ -86,7 +87,7 @@ fn mainnet_blocks_from_disk() {
         // Run several times to try catching a race condition if there is any.
         // 1000~2000 is a better choice for local testing after major changes.
         for _ in 0..3 {
-            common::test_execute_alloy(storage.clone(), block.clone(), true)
+            common::test_execute_alloy(storage.clone(), Chain::mainnet(), block.clone(), true)
         }
     });
 }

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -1,13 +1,12 @@
 // Test raw transfers -- A block with random raw transfers, ERC-20 transfers, and Uniswap swaps.
 
 use ahash::AHashMap;
-use alloy_chains::Chain;
 use alloy_primitives::U160;
 use pevm::InMemoryStorage;
 use rand::random;
 use revm::{
     db::PlainAccount,
-    primitives::{env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256},
+    primitives::{env::TxEnv, Address, TransactTo, U256},
 };
 
 pub mod common;
@@ -61,9 +60,6 @@ fn mixed_block() {
     }
     common::test_execute_revm(
         InMemoryStorage::new(final_state, []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
         // TODO: Shuffle transactions to scatter dependencies around the block.
         // Note that we'll need to guarantee that the nonces are increasing.
         final_txs,

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -1,6 +1,7 @@
 // Test raw transfers -- A block with random raw transfers, ERC-20 transfers, and Uniswap swaps.
 
 use ahash::AHashMap;
+use alloy_chains::Chain;
 use alloy_primitives::U160;
 use pevm::InMemoryStorage;
 use rand::random;
@@ -60,6 +61,7 @@ fn mixed_block() {
     }
     common::test_execute_revm(
         InMemoryStorage::new(final_state, []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         // TODO: Shuffle transactions to scatter dependencies around the block.

--- a/tests/raw_transfers.rs
+++ b/tests/raw_transfers.rs
@@ -4,9 +4,7 @@ use alloy_chains::Chain;
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
 use pevm::InMemoryStorage;
 use rand::random;
-use revm::primitives::{
-    alloy_primitives::U160, env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256,
-};
+use revm::primitives::{alloy_primitives::U160, env::TxEnv, Address, TransactTo, U256};
 
 pub mod common;
 
@@ -16,9 +14,6 @@ fn raw_transfers_independent() {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
         InMemoryStorage::new((0..=block_size).map(common::mock_account), []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
         // Mock `block_size` transactions sending some tokens to itself.
         // Skipping `Address::ZERO` as the beneficiary account.
         (1..=block_size)
@@ -49,9 +44,6 @@ fn raw_transfers_same_sender_multiple_txs() {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
         InMemoryStorage::new((0..=block_size).map(common::mock_account), []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
         (1..=block_size)
             .map(|i| {
                 // Insert a "parallel" transaction every ~256 transactions

--- a/tests/raw_transfers.rs
+++ b/tests/raw_transfers.rs
@@ -1,5 +1,6 @@
 // Test raw transfers -- only send some ETH from one account to another without extra data.
 
+use alloy_chains::Chain;
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
 use pevm::InMemoryStorage;
 use rand::random;
@@ -15,6 +16,7 @@ fn raw_transfers_independent() {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
         InMemoryStorage::new((0..=block_size).map(common::mock_account), []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         // Mock `block_size` transactions sending some tokens to itself.
@@ -47,6 +49,7 @@ fn raw_transfers_same_sender_multiple_txs() {
     common::test_execute_revm(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
         InMemoryStorage::new((0..=block_size).map(common::mock_account), []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         (1..=block_size)
@@ -82,6 +85,7 @@ fn raw_transfers_independent_alloy() {
     common::test_execute_alloy(
         // Mock the beneficiary account (`Address:ZERO`) and the next `block_size` user accounts.
         InMemoryStorage::new((0..=block_size).map(common::mock_account), []),
+        Chain::mainnet(),
         Block {
             header: common::MOCK_ALLOY_BLOCK_HEADER.clone(),
             transactions: BlockTransactions::Full(

--- a/tests/small_blocks.rs
+++ b/tests/small_blocks.rs
@@ -1,6 +1,7 @@
 // Test small blocks that we have specific handling for, like implicit fine-tuning
 // the concurrency level, falling back to sequential processing, etc.
 
+use alloy_chains::Chain;
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
 use pevm::InMemoryStorage;
@@ -12,6 +13,7 @@ pub mod common;
 fn empty_alloy_block() {
     common::test_execute_alloy(
         InMemoryStorage::default(),
+        Chain::mainnet(),
         Block {
             header: common::MOCK_ALLOY_BLOCK_HEADER.clone(),
             transactions: BlockTransactions::Full(Vec::new()),
@@ -25,6 +27,7 @@ fn empty_alloy_block() {
 fn empty_revm_block() {
     common::test_execute_revm(
         InMemoryStorage::default(),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         Vec::new(),
@@ -35,6 +38,7 @@ fn empty_revm_block() {
 fn one_tx_alloy_block() {
     common::test_execute_alloy(
         InMemoryStorage::new([common::mock_account(0)], []),
+        Chain::mainnet(),
         Block {
             // Legit header but with no transactions
             header: common::MOCK_ALLOY_BLOCK_HEADER.clone(),
@@ -57,6 +61,7 @@ fn one_tx_alloy_block() {
 fn one_tx_revm_block() {
     common::test_execute_revm(
         InMemoryStorage::new([common::mock_account(0)], []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         vec![TxEnv {

--- a/tests/small_blocks.rs
+++ b/tests/small_blocks.rs
@@ -5,7 +5,7 @@ use alloy_chains::Chain;
 use alloy_primitives::{Address, U256};
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
 use pevm::InMemoryStorage;
-use revm::primitives::{BlockEnv, SpecId, TransactTo, TxEnv};
+use revm::primitives::{TransactTo, TxEnv};
 
 pub mod common;
 
@@ -25,13 +25,7 @@ fn empty_alloy_block() {
 
 #[test]
 fn empty_revm_block() {
-    common::test_execute_revm(
-        InMemoryStorage::default(),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
-        Vec::new(),
-    );
+    common::test_execute_revm(InMemoryStorage::default(), Vec::new());
 }
 
 #[test]
@@ -61,9 +55,6 @@ fn one_tx_alloy_block() {
 fn one_tx_revm_block() {
     common::test_execute_revm(
         InMemoryStorage::new([common::mock_account(0)], []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
         vec![TxEnv {
             caller: Address::ZERO,
             transact_to: TransactTo::Call(Address::ZERO),

--- a/tests/uniswap/main.rs
+++ b/tests/uniswap/main.rs
@@ -13,11 +13,10 @@ pub mod uniswap;
 
 use crate::uniswap::generate_cluster;
 use ahash::AHashMap;
-use alloy_chains::Chain;
 use pevm::InMemoryStorage;
 use revm::{
     db::PlainAccount,
-    primitives::{Address, BlockEnv, SpecId, TxEnv},
+    primitives::{Address, TxEnv},
 };
 
 #[test]
@@ -33,11 +32,5 @@ fn uniswap_clusters() {
         final_state.extend(state);
         final_txs.extend(txs);
     }
-    common::test_execute_revm(
-        InMemoryStorage::new(final_state, []),
-        Chain::mainnet(),
-        SpecId::LATEST,
-        BlockEnv::default(),
-        final_txs,
-    )
+    common::test_execute_revm(InMemoryStorage::new(final_state, []), final_txs)
 }

--- a/tests/uniswap/main.rs
+++ b/tests/uniswap/main.rs
@@ -13,6 +13,7 @@ pub mod uniswap;
 
 use crate::uniswap::generate_cluster;
 use ahash::AHashMap;
+use alloy_chains::Chain;
 use pevm::InMemoryStorage;
 use revm::{
     db::PlainAccount,
@@ -34,6 +35,7 @@ fn uniswap_clusters() {
     }
     common::test_execute_revm(
         InMemoryStorage::new(final_state, []),
+        Chain::mainnet(),
         SpecId::LATEST,
         BlockEnv::default(),
         final_txs,


### PR DESCRIPTION
These changes are made to prepare for https://github.com/risechain/pevm/pull/168.

**Before**

```
CfgEnv::default()
```

**After**

```
CfgEnv::default().with_chain_id(chain.id())
```