### PR TITLE
perf: transactions_dependencies just need count number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,7 +132,7 @@ type TransactionsStatus = Vec<TxStatus>;
 // TODO: Intuitively both should share a similar data structure?
 // TODO: Consider using [SmallVec] for these `[DepsList]`
 type TransactionsDependents = Vec<Vec<TxIdx>>;
-type TransactionsDependencies = HashMap<TxIdx, Vec<TxIdx>, BuildIdentityHasher>;
+type TransactionsDependenciesNum = HashMap<TxIdx, usize, BuildIdentityHasher>;
 
 // We maintain an in-memory multi-version data structure that stores for
 // each memory location the latest value written per transaction, along

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -22,7 +22,7 @@ use crate::{
     storage::StorageWrapper,
     vm::{execute_tx, ExecutionError, PevmTxExecutionResult, Vm, VmExecutionResult},
     AccountBasic, BuildAddressHasher, BuildIdentityHasher, EvmAccount, IncarnationStatus,
-    MemoryEntry, MemoryLocation, MemoryValue, Storage, Task, TransactionsDependencies,
+    MemoryEntry, MemoryLocation, MemoryValue, Storage, Task, TransactionsDependenciesNum,
     TransactionsDependents, TransactionsStatus, TxIdx, TxStatus, TxVersion,
 };
 
@@ -327,9 +327,9 @@ fn preprocess_dependencies(
         .collect();
     let mut transactions_dependents: TransactionsDependents = vec![vec![]; block_size];
     let mut transactions_dependencies =
-        TransactionsDependencies::with_hasher(BuildIdentityHasher::default());
+        TransactionsDependenciesNum::with_hasher(BuildIdentityHasher::default());
 
-    // Marking transactions from thee same sender as dependencies to avoid fatal nonce errors.
+    // Marking transactions from the same sender as dependencies to avoid fatal nonce errors.
     let mut last_tx_idx_by_sender = HashMap::<Address, TxIdx, BuildAddressHasher>::default();
 
     for (tx_idx, tx) in txs.iter().enumerate() {
@@ -343,7 +343,7 @@ fn preprocess_dependencies(
                         .get_unchecked_mut(*dependency_idx)
                         .push(tx_idx);
                 }
-                transactions_dependencies.insert(tx_idx, dependency_idxs);
+                transactions_dependencies.insert(tx_idx, dependency_idxs.len());
             }
         };
 

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -10,8 +10,8 @@ use std::{
 use crossbeam::utils::CachePadded;
 
 use crate::{
-    BuildIdentityHasher, IncarnationStatus, Task, TransactionsDependencies, TransactionsDependents,
-    TransactionsStatus, TxIdx, TxStatus, TxVersion,
+    BuildIdentityHasher, IncarnationStatus, Task, TransactionsDependenciesNum,
+    TransactionsDependents, TransactionsStatus, TxIdx, TxStatus, TxVersion,
 };
 
 // The Pevm collaborative scheduler coordinates execution & validation
@@ -76,8 +76,7 @@ pub(crate) struct Scheduler {
     // For instance, for a transaction to depend on two lower others,
     // one send to the same recipient address, and one is from
     // the same sender.
-    // TODO: Build a fuller dependency graph.
-    transactions_dependencies: HashMap<TxIdx, Mutex<Vec<TxIdx>>, BuildIdentityHasher>,
+    transactions_dependencies_num: HashMap<TxIdx, AtomicUsize, BuildIdentityHasher>,
 }
 
 impl Scheduler {
@@ -85,7 +84,7 @@ impl Scheduler {
         block_size: usize,
         transactions_status: TransactionsStatus,
         transactions_dependents: TransactionsDependents,
-        transactions_dependencies: TransactionsDependencies,
+        transactions_dependencies: TransactionsDependenciesNum,
     ) -> Self {
         Self {
             block_size,
@@ -98,9 +97,9 @@ impl Scheduler {
                 .into_iter()
                 .map(Mutex::new)
                 .collect(),
-            transactions_dependencies: transactions_dependencies
+            transactions_dependencies_num: transactions_dependencies
                 .into_iter()
-                .map(|(tx_idx, deps)| (tx_idx, Mutex::new(deps)))
+                .map(|(tx_idx, deps_num)| (tx_idx, AtomicUsize::new(deps_num)))
                 .collect(),
             // We won't validate until we find the first transaction that
             // reads or writes outside of its preprocessed dependencies.
@@ -194,6 +193,10 @@ impl Scheduler {
             blocking_dependents.push(tx_idx);
             drop(blocking_dependents);
 
+            if let Some(dep_num) = self.transactions_dependencies_num.get(&tx_idx) {
+                dep_num.fetch_add(1, Ordering::Release);
+            }
+
             return true;
         }
 
@@ -226,12 +229,11 @@ impl Scheduler {
             let mut dependents = index_mutex!(self.transactions_dependents, tx_version.tx_idx);
             let mut min_dependent_idx = None;
             for tx_idx in dependents.iter() {
-                if let Some(deps) = self.transactions_dependencies.get(tx_idx) {
-                    let mut deps = deps.lock().unwrap();
-                    deps.retain(|dep_idx| dep_idx != &tx_version.tx_idx);
+                if let Some(dep_num) = self.transactions_dependencies_num.get(tx_idx) {
+                    let original_dep_num = dep_num.fetch_sub(1, Ordering::Release);
                     // Skip this dependent as it has other pending dependencies.
                     // Let the last one evoke it.
-                    if !deps.is_empty() {
+                    if original_dep_num > 1 {
                         continue;
                     }
                 }


### PR DESCRIPTION
`transactions_dependencies` is just used to determine if a transaction still has predecessor dependencies.
So, we just use a `AtomicUsize` to count its size.