### PR TITLE
Use EvmAccount instead of PlainAccount

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # Put this behind a feature flag if there are use cases & users
 # that need more security guarantees even for internally hashing
 # EVM memory locations (we do not persist these hashes).
-ahash = { version = "0.8.11", features = ["serde"] }
+ahash = { version = "0.8.11" }
 alloy-chains = { version = "0.1.22" }
 alloy-primitives = { version = "0.7.5", features = ["asm-keccak"] }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
@@ -15,7 +15,6 @@ bitvec = "1.0.1"
 crossbeam = "0.8.4"
 dashmap = "6.0.0"
 defer-drop = "1.3.0"
-serde = "1.0.203"
 
 # Let's do our best to port needed REVM changes upstream
 revm = { git = "https://github.com/risechain/revm", rev = "979d069f0c2798f416c57f82ca1ebef46d257c4e", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 # Put this behind a feature flag if there are use cases & users
 # that need more security guarantees even for internally hashing
 # EVM memory locations (we do not persist these hashes).
-ahash = "0.8.11"
+ahash = { version = "0.8.11", features = ["serde"] }
 alloy-chains = { version = "0.1.22" }
 alloy-primitives = { version = "0.7.5", features = ["asm-keccak"] }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy", rev = "a4bb5f0be3eec5c8679bdab93c1482df38ba8509" }
@@ -15,6 +15,7 @@ bitvec = "1.0.1"
 crossbeam = "0.8.4"
 dashmap = "6.0.0"
 defer-drop = "1.3.0"
+serde = "1.0.203"
 
 # Let's do our best to port needed REVM changes upstream
 revm = { git = "https://github.com/risechain/revm", rev = "979d069f0c2798f416c57f82ca1ebef46d257c4e", features = [

--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -10,11 +10,8 @@ use ahash::AHashMap;
 use alloy_chains::Chain;
 use alloy_primitives::{Address, U160, U256};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pevm::{execute_revm, execute_revm_sequential, InMemoryStorage};
-use revm::{
-    db::PlainAccount,
-    primitives::{BlockEnv, SpecId, TransactTo, TxEnv},
-};
+use pevm::{execute_revm, execute_revm_sequential, EvmAccount, InMemoryStorage};
+use revm::primitives::{BlockEnv, SpecId, TransactTo, TxEnv};
 
 // Better project structure
 #[path = "../tests/common/mod.rs"]
@@ -89,13 +86,13 @@ pub fn bench_raw_transfers(c: &mut Criterion) {
 pub fn bench_erc20(c: &mut Criterion) {
     let block_size = (GIGA_GAS as f64 / erc20::GAS_LIMIT as f64).ceil() as usize;
     let (mut state, txs) = erc20::generate_cluster(block_size, 1, 1);
-    state.insert(Address::ZERO, PlainAccount::default()); // Beneficiary
+    state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     bench(c, "Independent ERC20", state, txs);
 }
 
 pub fn bench_uniswap(c: &mut Criterion) {
     let block_size = (GIGA_GAS as f64 / uniswap::GAS_LIMIT as f64).ceil() as usize;
-    let mut final_state = AHashMap::from([(Address::ZERO, PlainAccount::default())]); // Beneficiary
+    let mut final_state = AHashMap::from([(Address::ZERO, EvmAccount::default())]); // Beneficiary
     let mut final_txs = Vec::<TxEnv>::new();
     for _ in 0..block_size {
         let (state, txs) = uniswap::generate_cluster(1, 1);

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -9,13 +9,12 @@ use revm::{
     primitives::{Account, AccountInfo, Bytecode, JumpTable},
     DatabaseRef,
 };
-use serde::{Deserialize, Serialize};
 
 /// An EVM account.
 // TODO: Flatten [AccountBasic] or more ideally, replace this with an Alloy type.
 // [AccountBasic] works for now as we're tightly tied to REVM types, hence
 // conversions between [AccountBasic] & [AccountInfo] are very convenient.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct EvmAccount {
     /// The account's basic information.
     pub basic: AccountBasic,
@@ -24,13 +23,21 @@ pub struct EvmAccount {
 }
 
 impl EvmAccount {
-    /// Create `PlainAccount` from `EvmAccount`.
-    ///
-    /// This is useful for testing and conversion between storage types.
-    pub fn into_plain(self) -> PlainAccount {
+    /// Create a new `EvmAccount` with a given balance.
+    pub fn with_balance(balance: U256) -> Self {
+        AccountBasic {
+            balance,
+            ..Default::default()
+        }
+        .into()
+    }
+}
+
+impl From<EvmAccount> for PlainAccount {
+    fn from(account: EvmAccount) -> Self {
         PlainAccount {
-            info: self.basic.into(),
-            storage: self.storage.into_iter().collect(),
+            info: account.basic.into(),
+            storage: account.storage.into_iter().collect(),
         }
     }
 }
@@ -68,7 +75,7 @@ impl From<AccountBasic> for EvmAccount {
 
 /// Basic information of an account
 // TODO: Reuse something sane from Alloy?
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct AccountBasic {
     /// The balance of the account.
     pub balance: U256,
@@ -81,28 +88,10 @@ pub struct AccountBasic {
 }
 
 impl AccountBasic {
-    /// Create a new account with the given balance, nonce, code hash and code.
-    pub fn new(balance: U256, nonce: u64, code_hash: B256, code: EvmCode) -> Self {
-        AccountBasic {
-            balance,
-            nonce,
-            code: Some(code),
-            code_hash: Some(code_hash),
-        }
-    }
-
     /// Check if an account is empty for removal per EIP-161
     // https://github.com/ethereum/EIPs/blob/96523ef4d76ca440f73f0403ddb5c9cb3b24dcae/EIPS/eip-161.md
     pub fn is_empty(&self) -> bool {
         self.balance == U256::ZERO && self.nonce == 0 && self.code.is_none()
-    }
-
-    /// Create a new account with the given balance.
-    pub fn from_balance(balance: U256) -> Self {
-        AccountBasic {
-            balance,
-            ..Default::default()
-        }
     }
 }
 
@@ -139,7 +128,7 @@ impl From<AccountInfo> for AccountBasic {
 
 /// EVM Code, currently mapping to REVM's [ByteCode::LegacyAnalyzed].
 // TODO: Support raw legacy & EOF
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Default)]
 pub struct EvmCode {
     /// Bytecode with 32 zero bytes padding
     bytecode: Bytes,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -23,6 +23,18 @@ pub struct EvmAccount {
     pub storage: AHashMap<U256, U256>,
 }
 
+impl EvmAccount {
+    /// Create `PlainAccount` from `EvmAccount`.
+    ///
+    /// This is useful for testing and conversion between storage types.
+    pub fn into_plain(self) -> PlainAccount {
+        PlainAccount {
+            info: self.basic.into(),
+            storage: self.storage.into_iter().collect(),
+        }
+    }
+}
+
 impl From<PlainAccount> for EvmAccount {
     fn from(account: PlainAccount) -> Self {
         EvmAccount {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,10 +8,7 @@ use ahash::AHashMap;
 use alloy_primitives::{Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types::{Block, Header};
 use pevm::{EvmAccount, InMemoryStorage};
-use revm::{
-    db::PlainAccount,
-    primitives::{Bytecode, KECCAK_EMPTY},
-};
+use revm::{db::PlainAccount, primitives::KECCAK_EMPTY};
 
 pub mod runner;
 pub use runner::{assert_execution_result, mock_account, test_execute_alloy, test_execute_revm};
@@ -81,7 +78,7 @@ pub fn for_each_block_from_disk(mut handler: impl FnMut(Block, InMemoryStorage))
 
         for (_, account) in accounts.iter_mut() {
             if let Some(code) = account.info.code.clone() {
-                let code_hash = Bytecode::from(code).hash_slow();
+                let code_hash = code.hash_slow();
                 account.info.code_hash = code_hash;
             } else {
                 account.info.code_hash = KECCAK_EMPTY;

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -3,22 +3,21 @@ use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Bloom, B256};
 use alloy_provider::network::eip2718::Encodable2718;
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
-use pevm::{PevmResult, PevmTxExecutionResult, Storage};
-use revm::{
-    db::PlainAccount,
-    primitives::{alloy_primitives::U160, AccountInfo, Address, BlockEnv, SpecId, TxEnv, U256},
-};
+use pevm::{AccountBasic, EvmAccount, PevmResult, PevmTxExecutionResult, Storage};
+use revm::primitives::{alloy_primitives::U160, Address, BlockEnv, SpecId, TxEnv, U256};
 use std::{collections::BTreeMap, num::NonZeroUsize, thread};
 
 // Mock an account from an integer index that is used as the address.
 // Useful for mock iterations.
-pub fn mock_account(idx: usize) -> (Address, PlainAccount) {
+pub fn mock_account(idx: usize) -> (Address, EvmAccount) {
     let address = Address::from(U160::from(idx));
     (
         address,
         // Filling half full accounts to have enough tokens for tests without worrying about
         // the corner case of balance not going beyond `U256::MAX`.
-        PlainAccount::from(AccountInfo::from_balance(U256::MAX.div_ceil(U256::from(2)))),
+        EvmAccount::from(AccountBasic::from_balance(
+            U256::MAX.div_ceil(U256::from(2)),
+        )),
     )
 }
 

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -3,7 +3,7 @@ use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{Bloom, B256};
 use alloy_provider::network::eip2718::Encodable2718;
 use alloy_rpc_types::{Block, BlockTransactions, Transaction};
-use pevm::{AccountBasic, EvmAccount, PevmResult, PevmTxExecutionResult, Storage};
+use pevm::{EvmAccount, PevmResult, PevmTxExecutionResult, Storage};
 use revm::primitives::{alloy_primitives::U160, Address, BlockEnv, SpecId, TxEnv, U256};
 use std::{collections::BTreeMap, num::NonZeroUsize, thread};
 
@@ -15,9 +15,7 @@ pub fn mock_account(idx: usize) -> (Address, EvmAccount) {
         address,
         // Filling half full accounts to have enough tokens for tests without worrying about
         // the corner case of balance not going beyond `U256::MAX`.
-        EvmAccount::from(AccountBasic::from_balance(
-            U256::MAX.div_ceil(U256::from(2)),
-        )),
+        EvmAccount::with_balance(U256::MAX.div_ceil(U256::from(2))),
     )
 }
 

--- a/tests/common/storage.rs
+++ b/tests/common/storage.rs
@@ -1,19 +1,17 @@
-use revm::{
-    db::states::plain_account::PlainStorage,
-    primitives::{
-        alloy_primitives::U160, keccak256, ruint::UintTryFrom, Address, B256, I256, U256,
-    },
+use ahash::AHashMap;
+use revm::primitives::{
+    alloy_primitives::U160, keccak256, ruint::UintTryFrom, Address, B256, I256, U256,
 };
 
 #[derive(Debug, Default)]
 pub struct StorageBuilder {
-    dict: PlainStorage,
+    dict: AHashMap<U256, U256>,
 }
 
 impl StorageBuilder {
     pub fn new() -> Self {
         StorageBuilder {
-            dict: PlainStorage::new(),
+            dict: AHashMap::default(),
         }
     }
 
@@ -49,7 +47,7 @@ impl StorageBuilder {
         *entry = buffer.into();
     }
 
-    pub fn build(self) -> PlainStorage {
+    pub fn build(self) -> AHashMap<U256, U256> {
         self.dict
     }
 }

--- a/tests/erc20/contract.rs
+++ b/tests/erc20/contract.rs
@@ -1,11 +1,9 @@
 use crate::common::storage::{from_address, from_indices, from_short_string, StorageBuilder};
 use ahash::AHashMap;
-use revm::{
-    db::PlainAccount,
-    primitives::{
-        fixed_bytes, hex::FromHex, ruint::UintTryFrom, AccountInfo, Address, Bytecode, Bytes, B256,
-        U256,
-    },
+use pevm::{AccountBasic, EvmAccount};
+use revm::primitives::{
+    fixed_bytes, hex::FromHex, ruint::UintTryFrom, Address, Bytecode, Bytes, B256,
+    U256,
 };
 
 const ERC20_TOKEN: &str = include_str!("./assets/ERC20Token.hex");
@@ -64,7 +62,7 @@ impl ERC20Token {
     // | _name        | string                                          | 3    | 0      | 32    |
     // | _symbol      | string                                          | 4    | 0      | 32    |
     // | _decimals    | uint8                                           | 5    | 0      | 1     |
-    pub fn build(&self) -> PlainAccount {
+    pub fn build(&self) -> EvmAccount {
         let hex = ERC20_TOKEN.trim();
         let bytecode = Bytecode::new_raw(Bytes::from_hex(hex).unwrap());
 
@@ -87,9 +85,15 @@ impl ERC20Token {
             );
         }
 
-        PlainAccount {
-            info: AccountInfo::new(U256::ZERO, 1u64, bytecode.hash_slow(), bytecode.clone()),
-            storage: store.build(),
+        EvmAccount {
+            basic: AccountBasic::new(
+                U256::ZERO,
+                1u64,
+                bytecode.hash_slow(),
+                bytecode.clone().into(),
+            )
+            .into(),
+            storage: store.build().into_iter().collect(),
         }
     }
 

--- a/tests/erc20/contract.rs
+++ b/tests/erc20/contract.rs
@@ -85,13 +85,13 @@ impl ERC20Token {
         }
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 

--- a/tests/erc20/contract.rs
+++ b/tests/erc20/contract.rs
@@ -2,8 +2,7 @@ use crate::common::storage::{from_address, from_indices, from_short_string, Stor
 use ahash::AHashMap;
 use pevm::{AccountBasic, EvmAccount};
 use revm::primitives::{
-    fixed_bytes, hex::FromHex, ruint::UintTryFrom, Address, Bytecode, Bytes, B256,
-    U256,
+    fixed_bytes, hex::FromHex, ruint::UintTryFrom, Address, Bytecode, Bytes, B256, U256,
 };
 
 const ERC20_TOKEN: &str = include_str!("./assets/ERC20Token.hex");
@@ -91,8 +90,7 @@ impl ERC20Token {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -11,17 +11,14 @@ pub mod erc20;
 use ahash::AHashMap;
 use common::test_execute_revm;
 use erc20::generate_cluster;
-use pevm::InMemoryStorage;
-use revm::{
-    db::PlainAccount,
-    primitives::{Address, TxEnv},
-};
+use pevm::{EvmAccount, InMemoryStorage};
+use revm::primitives::{Address, BlockEnv, SpecId, TxEnv};
 
 #[test]
 fn erc20_independent() {
     const N: usize = 37123;
     let (mut state, txs) = generate_cluster(N, 1, 1);
-    state.insert(Address::ZERO, PlainAccount::default()); // Beneficiary
+    state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     test_execute_revm(InMemoryStorage::new(state, []), txs);
 }
 
@@ -32,7 +29,7 @@ fn erc20_clusters() {
     const NUM_PEOPLE_PER_FAMILY: usize = 15;
     const NUM_TRANSFERS_PER_PERSON: usize = 15;
 
-    let mut final_state = AHashMap::from([(Address::ZERO, PlainAccount::default())]); // Beneficiary
+    let mut final_state = AHashMap::from([(Address::ZERO, EvmAccount::default())]); // Beneficiary
     let mut final_txs = Vec::<TxEnv>::new();
     for _ in 0..NUM_CLUSTERS {
         let (state, txs) = generate_cluster(

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -12,7 +12,7 @@ use ahash::AHashMap;
 use common::test_execute_revm;
 use erc20::generate_cluster;
 use pevm::{EvmAccount, InMemoryStorage};
-use revm::primitives::{Address, BlockEnv, SpecId, TxEnv};
+use revm::primitives::{Address, TxEnv};
 
 #[test]
 fn erc20_independent() {

--- a/tests/erc20/mod.rs
+++ b/tests/erc20/mod.rs
@@ -2,10 +2,8 @@ pub mod contract;
 
 use ahash::AHashMap;
 use contract::ERC20Token;
-use revm::{
-    db::PlainAccount,
-    primitives::{uint, AccountInfo, Address, TransactTo, TxEnv, U256},
-};
+use pevm::{AccountBasic, EvmAccount};
+use revm::primitives::{uint, Address, TransactTo, TxEnv, U256};
 
 use crate::common::ChainState;
 
@@ -39,8 +37,8 @@ pub fn generate_cluster(
     let mut txs = Vec::new();
 
     for person in people_addresses.iter() {
-        let info = AccountInfo::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
-        state.insert(*person, PlainAccount::from(info));
+        let basic = AccountBasic::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
+        state.insert(*person, EvmAccount::from(basic));
     }
 
     for nonce in 0..num_transfers_per_person {

--- a/tests/erc20/mod.rs
+++ b/tests/erc20/mod.rs
@@ -2,7 +2,7 @@ pub mod contract;
 
 use ahash::AHashMap;
 use contract::ERC20Token;
-use pevm::{AccountBasic, EvmAccount};
+use pevm::EvmAccount;
 use revm::primitives::{uint, Address, TransactTo, TxEnv, U256};
 
 use crate::common::ChainState;
@@ -37,8 +37,10 @@ pub fn generate_cluster(
     let mut txs = Vec::new();
 
     for person in people_addresses.iter() {
-        let basic = AccountBasic::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
-        state.insert(*person, EvmAccount::from(basic));
+        state.insert(
+            *person,
+            EvmAccount::with_balance(uint!(4_567_000_000_000_000_000_000_U256)),
+        );
     }
 
     for nonce in 0..num_transfers_per_person {

--- a/tests/mainnet.rs
+++ b/tests/mainnet.rs
@@ -68,7 +68,7 @@ fn mainnet_blocks_from_rpc() {
             let accounts: BTreeMap<Address, PlainAccount> = rpc_storage
                 .get_cache_accounts()
                 .into_iter()
-                .map(|(address, evm_account)| (address, evm_account.into_plain()))
+                .map(|(address, evm_account)| (address, evm_account.into()))
                 .collect();
             let file_state = File::create(format!("{dir}/pre_state.json")).unwrap();
             serde_json::to_writer(file_state, &accounts).unwrap();

--- a/tests/mainnet.rs
+++ b/tests/mainnet.rs
@@ -65,8 +65,11 @@ fn mainnet_blocks_from_rpc() {
 
             // TODO: Snapshot with consistent ordering for ease of diffing.
             // Currently PlainAccount's storage ordering isn't consistent.
-            let accounts: BTreeMap<Address, PlainAccount> =
-                rpc_storage.get_cache_accounts().into_iter().collect();
+            let accounts: BTreeMap<Address, PlainAccount> = rpc_storage
+                .get_cache_accounts()
+                .into_iter()
+                .map(|(address, evm_account)| (address, evm_account.into_plain()))
+                .collect();
             let file_state = File::create(format!("{dir}/pre_state.json")).unwrap();
             serde_json::to_writer(file_state, &accounts).unwrap();
 

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -4,8 +4,7 @@ use ahash::AHashMap;
 use alloy_primitives::U160;
 use pevm::{EvmAccount, InMemoryStorage};
 use rand::random;
-use revm::
-    primitives::{env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256};
+use revm::primitives::{env::TxEnv, Address, TransactTo, U256};
 
 pub mod common;
 pub mod erc20;

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -2,12 +2,10 @@
 
 use ahash::AHashMap;
 use alloy_primitives::U160;
-use pevm::InMemoryStorage;
+use pevm::{EvmAccount, InMemoryStorage};
 use rand::random;
-use revm::{
-    db::PlainAccount,
-    primitives::{env::TxEnv, Address, TransactTo, U256},
-};
+use revm::
+    primitives::{env::TxEnv, Address, BlockEnv, SpecId, TransactTo, U256};
 
 pub mod common;
 pub mod erc20;
@@ -20,7 +18,7 @@ fn mixed_block() {
     // TODO: Run a few times
     let mut block_size = 0;
     let mut final_state = AHashMap::new();
-    final_state.insert(Address::ZERO, PlainAccount::default()); // Beneficiary
+    final_state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     let mut final_txs = Vec::new();
     // 1 to 10
     let small_random = || (random::<u8>() % 10 + 1) as usize;

--- a/tests/uniswap/contract.rs
+++ b/tests/uniswap/contract.rs
@@ -50,13 +50,13 @@ impl WETH9 {
         store.set(5, 0); // mapping
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 }
@@ -130,13 +130,13 @@ impl UniswapV3Factory {
         }
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 }
@@ -252,13 +252,13 @@ impl UniswapV3Pool {
         }
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 
@@ -324,13 +324,13 @@ impl SwapRouter {
         );
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 }
@@ -370,13 +370,13 @@ impl SingleSwap {
         store.set_with_offset(1, 20, 3, POOL_FEE);
 
         EvmAccount {
-            basic: AccountBasic::new(
-                U256::ZERO,
-                1u64,
-                bytecode.hash_slow(),
-                bytecode.clone().into(),
-            ),
-            storage: store.build().into_iter().collect(),
+            basic: AccountBasic {
+                balance: U256::ZERO,
+                nonce: 1u64,
+                code: Some(bytecode.clone().into()),
+                code_hash: Some(bytecode.hash_slow()),
+            },
+            storage: store.build(),
         }
     }
 }

--- a/tests/uniswap/contract.rs
+++ b/tests/uniswap/contract.rs
@@ -55,8 +55,7 @@ impl WETH9 {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }
@@ -136,8 +135,7 @@ impl UniswapV3Factory {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }
@@ -259,8 +257,7 @@ impl UniswapV3Pool {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }
@@ -332,8 +329,7 @@ impl SwapRouter {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }
@@ -379,8 +375,7 @@ impl SingleSwap {
                 1u64,
                 bytecode.hash_slow(),
                 bytecode.clone().into(),
-            )
-            .into(),
+            ),
             storage: store.build().into_iter().collect(),
         }
     }

--- a/tests/uniswap/main.rs
+++ b/tests/uniswap/main.rs
@@ -13,11 +13,8 @@ pub mod uniswap;
 
 use crate::uniswap::generate_cluster;
 use ahash::AHashMap;
-use pevm::InMemoryStorage;
-use revm::{
-    db::PlainAccount,
-    primitives::{Address, TxEnv},
-};
+use pevm::{EvmAccount, InMemoryStorage};
+use revm::primitives::{Address, TxEnv};
 
 #[test]
 fn uniswap_clusters() {
@@ -25,7 +22,7 @@ fn uniswap_clusters() {
     const NUM_PEOPLE_PER_CLUSTER: usize = 20;
     const NUM_SWAPS_PER_PERSON: usize = 20;
 
-    let mut final_state = AHashMap::from([(Address::ZERO, PlainAccount::default())]); // Beneficiary
+    let mut final_state = AHashMap::from([(Address::ZERO, EvmAccount::default())]); // Beneficiary
     let mut final_txs = Vec::<TxEnv>::new();
     for _ in 0..NUM_CLUSTERS {
         let (state, txs) = generate_cluster(NUM_PEOPLE_PER_CLUSTER, NUM_SWAPS_PER_PERSON);

--- a/tests/uniswap/mod.rs
+++ b/tests/uniswap/mod.rs
@@ -3,10 +3,8 @@ pub mod contract;
 use crate::{common::ChainState, erc20::contract::ERC20Token};
 use ahash::AHashMap;
 use contract::{SingleSwap, SwapRouter, UniswapV3Factory, UniswapV3Pool, WETH9};
-use revm::{
-    db::PlainAccount,
-    primitives::{fixed_bytes, uint, AccountInfo, Address, Bytes, TransactTo, TxEnv, B256, U256},
-};
+use pevm::{AccountBasic, EvmAccount};
+use revm::primitives::{fixed_bytes, uint, Address, Bytes, TransactTo, TxEnv, B256, U256};
 
 pub const GAS_LIMIT: u64 = 155_934;
 
@@ -113,8 +111,8 @@ pub fn generate_cluster(
     ]);
 
     for person in people_addresses.iter() {
-        let info = AccountInfo::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
-        state.insert(*person, PlainAccount::from(info));
+        let basic = AccountBasic::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
+        state.insert(*person, EvmAccount::from(basic));
     }
 
     let mut txs = Vec::new();

--- a/tests/uniswap/mod.rs
+++ b/tests/uniswap/mod.rs
@@ -3,7 +3,7 @@ pub mod contract;
 use crate::{common::ChainState, erc20::contract::ERC20Token};
 use ahash::AHashMap;
 use contract::{SingleSwap, SwapRouter, UniswapV3Factory, UniswapV3Pool, WETH9};
-use pevm::{AccountBasic, EvmAccount};
+use pevm::EvmAccount;
 use revm::primitives::{fixed_bytes, uint, Address, Bytes, TransactTo, TxEnv, B256, U256};
 
 pub const GAS_LIMIT: u64 = 155_934;
@@ -111,8 +111,10 @@ pub fn generate_cluster(
     ]);
 
     for person in people_addresses.iter() {
-        let basic = AccountBasic::from_balance(uint!(4_567_000_000_000_000_000_000_U256));
-        state.insert(*person, EvmAccount::from(basic));
+        state.insert(
+            *person,
+            EvmAccount::with_balance(uint!(4_567_000_000_000_000_000_000_U256)),
+        );
     }
 
     let mut txs = Vec::new();


### PR DESCRIPTION
Note: This change is not implemented for accounts on the disk. Accounts are deserialised into `PlainAccount` for now.
Snapshot generation and serialisation of `EvmAccount` types must be done in subsequent PRs.