### PR TITLE
perf: remove useless fetch_add

### DIFF
--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -159,9 +159,7 @@ impl Scheduler {
                 if let Some(tx_version) = self.try_validate() {
                     return Some(Task::Validation(tx_version));
                 }
-            } else if let Some(tx_version) =
-                self.try_execute(self.execution_idx.fetch_add(1, Ordering::Release))
-            {
+            } else if let Some(tx_version) = self.try_execute(execution_idx) {
                 return Some(Task::Execution(tx_version));
             }
         }


### PR DESCRIPTION
When I read the source code, I found exist two `fetch_add`

- next_task
- try_execute inside

I found `fetch_add` in next_task is redundant.