### PR TITLE
chore: typo fix

### DIFF
--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -127,7 +127,7 @@ pub fn execute_revm<S: Storage + Send + Sync>(
         .iter()
         .filter_map(|tx| {
             if let TransactTo::Call(to_address) = tx.transact_to {
-                // TODO: Unifiy this condition with [Vm::execute]
+                // TODO: Unify this condition with [Vm::execute]
                 // TODO: Better error handling
                 if to_address != tx.caller && !storage.is_contract(&to_address).unwrap() {
                     return Some(to_address);


### PR DESCRIPTION
- typo fix
- use `while let` to make code clear