### PR TITLE
refactor: add chain as a parameter to functions calculate_receipt_root and get_block_spec

### DIFF
--- a/tests/mainnet.rs
+++ b/tests/mainnet.rs
@@ -49,7 +49,7 @@ fn mainnet_blocks_from_rpc() {
             )
             .unwrap()
             .unwrap();
-        let spec_id = pevm::get_block_spec(&block.header).unwrap();
+        let spec_id = pevm::get_block_spec(Chain::mainnet(), &block.header).unwrap();
         let rpc_storage = RpcStorage::new(provider, spec_id, BlockId::number(block_number - 1));
         let wrapped_storage = StorageWrapper(&rpc_storage);
         let db = CacheDB::new(&wrapped_storage);


### PR DESCRIPTION
One step towards https://github.com/risechain/pevm/issues/60

### 1. Adding parameter `chain: Chain`

`chain: Chain` has been added as a parameter to `get_block_spec`, `calculate_receipt_root`. Although the parameter might be unused for now, it will be used soon once we support other chains (e.g. Optimism Mainnet, Ethereum Sepolia).

### 2. Extract fn `encode_receipt_2718`

Another notable change of this PR is to extract `encode_receipt_2718` to a standalone function. By doing so, we can support other chains conveniently:

```rust
fn encode_receipt_2718(chain: Chain, tx_type: u8, tx_result: &PevmTxExecutionResult) {
  #[cfg(feature = "optimism")]
  if chain.is_optimism() && tx_type == 126 {
    return { ... }
  }

  ... // handler for Mainnet
}
```
