### PR TITLE
refactor: let pevm::execute accept spec_id as a parameter

### DIFF
--- a/benches/mainnet.rs
+++ b/benches/mainnet.rs
@@ -8,6 +8,7 @@ use std::{num::NonZeroUsize, thread};
 
 use alloy_chains::Chain;
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use pevm::get_block_spec;
 
 // Better project structure
 #[path = "../tests/common/mod.rs"]
@@ -32,11 +33,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             block.transactions.len(),
             block.header.gas_used
         ));
+        let spec_id = get_block_spec(&block.header).unwrap();
         group.bench_function("Sequential", |b| {
             b.iter(|| {
                 pevm::execute(
                     black_box(&storage),
                     black_box(chain),
+                    black_box(spec_id),
                     black_box(block.clone()),
                     black_box(concurrency_level),
                     black_box(true),
@@ -48,6 +51,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                 pevm::execute(
                     black_box(&storage),
                     black_box(chain),
+                    black_box(spec_id),
                     black_box(block.clone()),
                     black_box(concurrency_level),
                     black_box(false),

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -23,7 +23,7 @@ use revm::{
 
 use crate::{
     mv_memory::{LazyAddresses, MvMemory},
-    primitives::{get_block_env, get_block_spec, get_tx_env, TransactionParsingError},
+    primitives::{get_block_env, get_tx_env, TransactionParsingError},
     scheduler::Scheduler,
     storage::StorageWrapper,
     vm::{build_evm, ExecutionError, PevmTxExecutionResult, Vm, VmExecutionResult},
@@ -64,13 +64,11 @@ pub type PevmResult = Result<Vec<PevmTxExecutionResult>, PevmError>;
 pub fn execute<S: Storage + Send + Sync>(
     storage: &S,
     chain: Chain,
+    spec_id: SpecId,
     block: Block,
     concurrency_level: NonZeroUsize,
     force_sequential: bool,
 ) -> PevmResult {
-    let Some(spec_id) = get_block_spec(&block.header) else {
-        return Err(PevmError::UnknownBlockSpec);
-    };
     let Some(block_env) = get_block_env(&block.header) else {
         return Err(PevmError::MissingHeaderData);
     };


### PR DESCRIPTION
One step towards https://github.com/risechain/pevm/issues/60

We are gonna have:

```rust
let spec_id = get_optimism_block_spec(&block.header)?;
let result = pevm::execute(
        &db,
        chain,
        spec_id,
        block.clone(),
        concurrency_level,
        true,
);
```