### PR TITLE
refactor: extract fn get_mv_memory

### DIFF
--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -10,7 +10,7 @@ use ahash::AHashMap;
 use alloy_chains::Chain;
 use alloy_primitives::{Address, U160, U256};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pevm::{execute_revm, execute_revm_sequential, EvmAccount, InMemoryStorage};
+use pevm::{execute_revm_parallel, execute_revm_sequential, EvmAccount, InMemoryStorage};
 use revm::primitives::{BlockEnv, SpecId, TransactTo, TxEnv};
 
 // Better project structure
@@ -48,7 +48,7 @@ pub fn bench(c: &mut Criterion, name: &str, state: common::ChainState, txs: Vec<
     });
     group.bench_function("Parallel", |b| {
         b.iter(|| {
-            execute_revm(
+            execute_revm_parallel(
                 black_box(&storage),
                 black_box(chain),
                 black_box(spec_id),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,7 +206,7 @@ macro_rules! index_mutex {
 }
 
 mod pevm;
-pub use pevm::{execute, execute_revm, execute_revm_sequential, PevmError, PevmResult};
+pub use pevm::{execute, execute_revm_parallel, execute_revm_sequential, PevmError, PevmResult};
 mod mv_memory;
 mod primitives;
 pub use primitives::get_block_spec;

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -86,7 +86,7 @@ pub fn execute<S: Storage + Send + Sync>(
     if force_sequential || tx_envs.len() < 4 || block.header.gas_used < 2_000_000 {
         execute_revm_sequential(storage, chain, spec_id, block_env, tx_envs)
     } else {
-        execute_revm(
+        execute_revm_parallel(
             storage,
             chain,
             spec_id,
@@ -100,7 +100,7 @@ pub fn execute<S: Storage + Send + Sync>(
 /// Execute an REVM block.
 // Ideally everyone would go through the [Alloy] interface. This one is currently
 // useful for testing, and for users that are heavily tied to Revm like Reth.
-pub fn execute_revm<S: Storage + Send + Sync>(
+pub fn execute_revm_parallel<S: Storage + Send + Sync>(
     storage: &S,
     chain: Chain,
     spec_id: SpecId,
@@ -115,24 +115,10 @@ pub fn execute_revm<S: Storage + Send + Sync>(
     // Preprocess locations
     let block_size = txs.len();
     let hasher = ahash::RandomState::new();
-    let beneficiary_location_hash = hasher.hash_one(MemoryLocation::Basic(block_env.coinbase));
-    // TODO: Estimate more locations based on sender, to, etc.
-    let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());
-    estimated_locations.insert(
-        beneficiary_location_hash,
-        (0..block_size).collect::<Vec<TxIdx>>(),
-    );
-    let mut lazy_addresses = LazyAddresses::default();
-    lazy_addresses.0.insert(block_env.coinbase);
-
     // Initialize the remaining core components
     // TODO: Provide more explicit garbage collecting configs for users over random background
     // threads like this. For instance, to have a dedicated thread (pool) for cleanup.
-    let mv_memory = DeferDrop::new(MvMemory::new(
-        block_size,
-        estimated_locations,
-        lazy_addresses,
-    ));
+    let mv_memory = DeferDrop::new(build_mv_memory(&hasher, &block_env, block_size));
     let txs = DeferDrop::new(txs);
     let vm = Vm::new(
         &hasher, storage, &mv_memory, &txs, chain, spec_id, block_env,
@@ -297,6 +283,26 @@ pub fn execute_revm<S: Storage + Send + Sync>(
     }
 
     Ok(fully_evaluated_results)
+}
+
+fn build_mv_memory(
+    hasher: &ahash::RandomState,
+    block_env: &BlockEnv,
+    block_size: usize,
+) -> MvMemory {
+    let beneficiary_location_hash = hasher.hash_one(MemoryLocation::Basic(block_env.coinbase));
+
+    // TODO: Estimate more locations based on sender, to, etc.
+    let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());
+    estimated_locations.insert(
+        beneficiary_location_hash,
+        (0..block_size).collect::<Vec<TxIdx>>(),
+    );
+
+    let mut lazy_addresses = LazyAddresses::default();
+    lazy_addresses.0.insert(block_env.coinbase);
+
+    MvMemory::new(block_size, estimated_locations, lazy_addresses)
 }
 
 /// Execute REVM transactions sequentially.

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -35,7 +35,7 @@ pub fn test_execute_revm<S: Storage + Clone + Send + Sync>(storage: S, txs: Vec<
             BlockEnv::default(),
             txs.clone(),
         ),
-        &pevm::execute_revm(
+        &pevm::execute_revm_parallel(
             &storage,
             Chain::mainnet(),
             SpecId::LATEST,

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -125,7 +125,7 @@ fn run_test_unit(path: &Path, unit: TestUnit) {
 
             match (
                 test.expect_exception.as_deref(),
-                pevm::execute_revm(
+                pevm::execute_revm_parallel(
                     &InMemoryStorage::new(chain_state.clone(), []),
                     Chain::mainnet(),
                     spec_name.to_spec_id(),


### PR DESCRIPTION
One step towards https://github.com/risechain/pevm/issues/60

On the `optimism` branch, we will have:

```rust
    let mv_memory = 'b: {
        #[cfg(feature = "optimism")]
        if chain.is_optimism() {
            break 'b DeferDrop::new(get_optimism_mv_memory(&hasher, &block_env, &txs));
        }
        DeferDrop::new(get_mv_memory(&hasher, &block_env, &txs))
    };
```
