### PR TITLE
fix: correct nonce in unit test

### DIFF
--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -10,7 +10,7 @@ use ahash::AHashMap;
 use alloy_primitives::{Address, U160, U256};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pevm::{
-    execute_revm_parallel, execute_revm_sequential, chain::PevmEthereum, EvmAccount,
+    chain::PevmEthereum, execute_revm_parallel, execute_revm_sequential, EvmAccount,
     InMemoryStorage,
 };
 use revm::primitives::{BlockEnv, SpecId, TransactTo, TxEnv};

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -34,7 +34,7 @@ pub static MOCK_ALLOY_BLOCK_HEADER: Header = Header {
     logs_bloom: Bloom::ZERO,
     difficulty: U256::ZERO,
     gas_used: 0,
-    total_difficulty: None,
+    total_difficulty: Some(U256::ZERO),
     extra_data: Bytes::new(),
     nonce: None,
     base_fee_per_gas: None,

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -65,14 +65,14 @@ pub fn test_execute_alloy<
     let parallel_result = pevm::execute(storage, chain, block.clone(), concurrency_level, false);
     assert_execution_result(&sequential_result, &parallel_result);
 
+    let tx_results = sequential_result.unwrap();
     if must_match_block_header {
         let spec_id = chain.get_block_spec(&block.header).unwrap();
-        let tx_results = sequential_result.unwrap();
 
         // We can only calculate the receipts root from Byzantium.
         // Before EIP-658 (https://eips.ethereum.org/EIPS/eip-658), the
         // receipt root is calculated with the post transaction state root,
-        // which we doesn't have in these tests.
+        // which we don't have in these tests.
         if block.header.number.unwrap() >= 4370000 {
             assert_eq!(
                 block.header.receipts_root,

--- a/tests/raw_transfers.rs
+++ b/tests/raw_transfers.rs
@@ -89,6 +89,7 @@ fn raw_transfers_independent_alloy() {
                             value: U256::from(1),
                             gas: common::RAW_TRANSFER_GAS_LIMIT.into(),
                             max_fee_per_gas: Some(1),
+                            nonce: 1,
                             ..Transaction::default()
                         }
                     })

--- a/tests/small_blocks.rs
+++ b/tests/small_blocks.rs
@@ -37,6 +37,7 @@ fn one_tx_alloy_block() {
             header: common::MOCK_ALLOY_BLOCK_HEADER.clone(),
             transactions: BlockTransactions::Full(vec![Transaction {
                 transaction_type: Some(2),
+                nonce: 1,
                 from: Address::ZERO,
                 to: Some(Address::ZERO),
                 value: U256::from(1),


### PR DESCRIPTION
Test `one_tx_alloy_block` always throw error because of  wrong `nonce`.
