### PR TITLE
refactor: use fn push_origin to simplify code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,9 +153,14 @@ enum ReadOrigin {
     Storage,
 }
 
+// Most memory locations only have one read origin. Lazy updated ones like
+// the beneficiary balance, raw transfer senders & recipients, etc. have a
+// list of lazy updates all the way to the first strict/absolute value.
+type ReadOrigins = SmallVec<[ReadOrigin; 1]>;
+
 // For validation: a list of read origins (previous transaction versions)
 // for each read memory location.
-type ReadSet = HashMap<MemoryLocationHash, SmallVec<[ReadOrigin; 1]>, BuildIdentityHasher>;
+type ReadSet = HashMap<MemoryLocationHash, ReadOrigins, BuildIdentityHasher>;
 
 // The updates made by this transaction incarnation, which is applied
 // to the multi-version data structure at the end of execution.

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -54,7 +54,7 @@ pub(crate) struct Scheduler {
     min_validation_idx: AtomicUsize,
     // The number of validated transactions
     num_validated: AtomicUsize,
-    // True if the scheduler has been aborted, likely due to fatal exeuction
+    // True if the scheduler has been aborted, likely due to fatal execution
     // errors.
     aborted: AtomicBool,
 }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -220,7 +220,7 @@ impl<'a, S: Storage, C: PevmChain> Database for VmDb<'a, S, C> {
         let location_hash = self.hash_basic(&address);
 
         // We return a mock for non-contract addresses (for lazy updates) to avoid
-        // unncessarily evaluating its balance here.
+        // unnecessarily evaluating its balance here.
         if self.is_lazy {
             if location_hash == self.from_hash {
                 return Ok(Some(AccountInfo {

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -95,7 +95,7 @@ fn run_test_unit(path: &Path, unit: TestUnit) {
     unit.post.into_par_iter().for_each(|(spec_name, tests)| {
         // Constantinople was immediately extended by Petersburg.
         // There was technically never a Constantinople transaction on mainnet
-        // so REVM undestandably doesn't support it (without Petersburg).
+        // so REVM understandably doesn't support it (without Petersburg).
         if spec_name == SpecName::Constantinople {
             return;
         }


### PR DESCRIPTION
use fn push_origin to simplify code