### PR TITLE
fix: assert account balance and nonce in lazy evaluation

### DIFF
--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -262,8 +262,7 @@ impl Pevm {
                         MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
                             // We fall back to sequential execution when reading a self-destructed account,
                             // so an empty account here would be a bug
-                            debug_assert_ne!(info.balance, U256::ZERO);
-                            debug_assert_ne!(info.nonce, 0);
+                            debug_assert!(!(info.balance.is_zero() && info.nonce == 0));
                             balance = info.balance;
                             nonce = info.nonce;
                         }

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -260,8 +260,9 @@ impl Pevm {
                 for (tx_idx, memory_entry) in write_history.iter() {
                     match memory_entry {
                         MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
-                            // TODO: Assert that there must be no self-destructed
-                            // accounts here.
+                            // We fall back to sequential execution when reading a self-destructed account, so and empty account here would be a bug
+                            debug_assert_ne!(info.balance, U256::ZERO);
+                            debug_assert_ne!(info.nonce, 0);
                             balance = info.balance;
                             nonce = info.nonce;
                         }

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -260,7 +260,8 @@ impl Pevm {
                 for (tx_idx, memory_entry) in write_history.iter() {
                     match memory_entry {
                         MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
-                            // We fall back to sequential execution when reading a self-destructed account, so and empty account here would be a bug
+                            // We fall back to sequential execution when reading a self-destructed account,
+                            // so an empty account here would be a bug
                             debug_assert_ne!(info.balance, U256::ZERO);
                             debug_assert_ne!(info.nonce, 0);
                             balance = info.balance;


### PR DESCRIPTION
Resolve #312 