### PR TITLE
chore(`pevm`): Post-processing lazy evaluation: assert that the evaluated nonce matches the transaction's

### DIFF
--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -253,6 +253,7 @@ impl Pevm {
                 };
 
                 for (tx_idx, memory_entry) in write_history.iter() {
+                    let tx = unsafe { txs.get_unchecked(*tx_idx) };
                     match memory_entry {
                         MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
                             // We fall back to sequential execution when reading a self-destructed account,
@@ -271,7 +272,6 @@ impl Pevm {
                             // TODO: Guard against overflows & underflows
                             // Ideally we would share these calculations with revm
                             // (using their utility functions).
-                            let tx = unsafe { txs.get_unchecked(*tx_idx) };
                             let mut max_fee = U256::from(tx.gas_limit) * tx.gas_price + tx.value;
                             if let Some(blob_fee) = tx.max_fee_per_blob_gas {
                                 max_fee +=
@@ -291,7 +291,6 @@ impl Pevm {
                         _ => unreachable!(),
                     }
                     // Assert that evaluated nonce is correct when address is caller.
-                    let tx = unsafe { txs.get_unchecked(*tx_idx) };
                     debug_assert!(
                         tx.caller != address || tx.nonce.map_or(true, |n| n + 1 == nonce)
                     );

--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -255,20 +255,9 @@ impl Pevm {
                 for (tx_idx, memory_entry) in write_history.iter() {
                     match memory_entry {
                         MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
-                            // TODO: these debug assertions can later be converted to errors
                             // We fall back to sequential execution when reading a self-destructed account,
                             // so an empty account here would be a bug
                             debug_assert!(!(info.balance.is_zero() && info.nonce == 0));
-                            // Assert lazy evaluation tx nonce matches tx
-                            let tx = unsafe { txs.get_unchecked(*tx_idx) };
-                            if let Some(nonce) = tx.nonce {
-                                // TODO(edwardjes): remove
-                                if nonce + 1 != info.nonce {
-                                    println!("ACC {:#?}", info);
-                                    println!("TX {:#?}", tx);
-                                }
-                                debug_assert_eq!(nonce + 1, info.nonce);
-                            }
                             balance = info.balance;
                             nonce = info.nonce;
                         }
@@ -301,6 +290,11 @@ impl Pevm {
                         // TODO: Better error handling
                         _ => unreachable!(),
                     }
+                    // Assert that evaluated nonce is correct when address is caller.
+                    let tx = unsafe { txs.get_unchecked(*tx_idx) };
+                    debug_assert!(
+                        tx.caller != address || tx.nonce.map_or(true, |n| n + 1 == nonce)
+                    );
 
                     // SAFETY: The multi-version data structure should not leak an index over block size.
                     let tx_result = unsafe { fully_evaluated_results.get_unchecked_mut(*tx_idx) };


### PR DESCRIPTION
This PR addresses https://github.com/risechain/pevm/issues/310