### PR TITLE
feat: prioritize heavy txs

### DIFF
--- a/benches/gigagas.rs
+++ b/benches/gigagas.rs
@@ -4,13 +4,11 @@
 
 #![allow(missing_docs)]
 
-use std::{num::NonZeroUsize, thread};
-
 use alloy_primitives::{Address, U160, U256};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use pevm::{
     chain::PevmEthereum, execute_revm_sequential, Bytecodes, ChainState, EvmAccount,
-    InMemoryStorage, Pevm,
+    InMemoryStorage, ParallelParams, Pevm,
 };
 use revm::primitives::{BlockEnv, SpecId, TransactTo, TxEnv};
 
@@ -30,7 +28,6 @@ const GIGA_GAS: u64 = 1_000_000_000;
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 pub fn bench(c: &mut Criterion, name: &str, storage: InMemoryStorage, txs: Vec<TxEnv>) {
-    let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
     let chain = PevmEthereum::mainnet();
     let spec_id = SpecId::LATEST;
     let block_env = BlockEnv::default();
@@ -55,7 +52,7 @@ pub fn bench(c: &mut Criterion, name: &str, storage: InMemoryStorage, txs: Vec<T
                 black_box(spec_id),
                 black_box(block_env.clone()),
                 black_box(txs.clone()),
-                black_box(concurrency_level),
+                black_box(ParallelParams::default()),
             )
         })
     });

--- a/benches/mainnet.rs
+++ b/benches/mainnet.rs
@@ -4,10 +4,8 @@
 
 #![allow(missing_docs)]
 
-use std::{num::NonZeroUsize, thread};
-
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use pevm::{chain::PevmEthereum, Pevm};
+use pevm::{chain::PevmEthereum, Pevm, PevmStrategy};
 
 // Better project structure
 #[path = "../tests/common/mod.rs"]
@@ -23,21 +21,6 @@ static GLOBAL: rpmalloc::RpMalloc = rpmalloc::RpMalloc;
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     let chain = PevmEthereum::mainnet();
-    let concurrency_level = thread::available_parallelism()
-        .unwrap_or(NonZeroUsize::MIN)
-        // This max should be tuned to the running machine,
-        // ideally also per block depending on the number of
-        // transactions, gas usage, etc. ARM machines seem to
-        // go higher thanks to their low thread overheads.
-        .min(
-            NonZeroUsize::new(
-                #[cfg(target_arch = "aarch64")]
-                12,
-                #[cfg(not(target_arch = "aarch64"))]
-                8,
-            )
-            .unwrap(),
-        );
     let mut pevm = Pevm::default();
 
     common::for_each_block_from_disk(|block, storage| {
@@ -49,24 +32,29 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         ));
         group.bench_function("Sequential", |b| {
             b.iter(|| {
-                pevm.execute(
-                    black_box(&storage),
-                    black_box(&chain),
-                    black_box(block.clone()),
-                    black_box(concurrency_level),
-                    black_box(true),
-                )
+                assert!(pevm
+                    .execute(
+                        black_box(&storage),
+                        black_box(&chain),
+                        black_box(block.clone()),
+                        black_box(PevmStrategy::sequential()),
+                    )
+                    .is_ok());
             })
         });
         group.bench_function("Parallel", |b| {
             b.iter(|| {
-                pevm.execute(
-                    black_box(&storage),
-                    black_box(&chain),
-                    black_box(block.clone()),
-                    black_box(concurrency_level),
-                    black_box(false),
-                )
+                assert!(pevm
+                    .execute(
+                        black_box(&storage),
+                        black_box(&chain),
+                        black_box(block.clone()),
+                        black_box(PevmStrategy::auto(
+                            block.transactions.len(),
+                            block.header.gas_used,
+                        )),
+                    )
+                    .is_ok());
             })
         });
         group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -210,7 +210,9 @@ pub mod chain;
 mod compat;
 mod mv_memory;
 mod pevm;
-pub use pevm::{execute_revm_sequential, Pevm, PevmError, PevmResult};
+pub use pevm::{
+    execute_revm_sequential, ParallelParams, Pevm, PevmError, PevmResult, PevmStrategy,
+};
 mod scheduler;
 mod storage;
 pub use storage::{

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -48,6 +48,8 @@ pub(crate) struct Scheduler {
     // The list of dependent transactions to resume when the
     // key transaction is re-executed.
     transactions_dependents: Vec<Mutex<SmallVec<[TxIdx; 1]>>>,
+    // The next priority transaction to try and execute.
+    priority_idx: AtomicUsize,
     // The next transaction to try and execute.
     execution_idx: AtomicUsize,
     // The next transaction to try and validate.
@@ -57,17 +59,19 @@ pub(crate) struct Scheduler {
     min_validation_idx: AtomicUsize,
     // The number of validated transactions
     num_validated: AtomicUsize,
-    // True if the scheduler has been aborted, likely due to fatal execution
-    // errors.
+    // True if the scheduler has been aborted, likely due to fatal execution errors.
     aborted: AtomicBool,
+    // We prioritize the heaviest txs (highest gas_limit).
+    priority_txs: Vec<TxIdx>,
 }
 
 // TODO: Better error handling.
 // Like returning errors instead of panicking on [unreachable]s.
 impl Scheduler {
-    pub(crate) fn new(block_size: usize) -> Self {
+    pub(crate) fn new(block_size: usize, priority_txs: impl IntoIterator<Item = TxIdx>) -> Self {
         Self {
             block_size,
+            priority_idx: AtomicUsize::new(0),
             execution_idx: AtomicUsize::new(0),
             transactions_status: (0..block_size)
                 .map(|_| {
@@ -84,6 +88,7 @@ impl Scheduler {
             min_validation_idx: AtomicUsize::new(block_size),
             num_validated: AtomicUsize::new(0),
             aborted: AtomicBool::new(false),
+            priority_txs: Vec::from_iter(priority_txs),
         }
     }
 
@@ -103,6 +108,27 @@ impl Scheduler {
             }
         }
         None
+    }
+
+    pub(crate) fn next_priority_task(&self) -> Option<Task> {
+        loop {
+            if self.aborted.load(Ordering::Acquire) {
+                return None;
+            }
+            if self.priority_idx.load(Ordering::Acquire) >= self.priority_txs.len() {
+                return None;
+            }
+            let priority_idx = self.priority_idx.fetch_add(1, Ordering::Release);
+            let tx_idx = self.priority_txs.get(priority_idx).copied()?;
+            let mut tx = index_mutex!(self.transactions_status, tx_idx);
+            if tx.status == IncarnationStatus::ReadyToExecute {
+                tx.status = IncarnationStatus::Executing;
+                return Some(Task::Execution(TxVersion {
+                    tx_idx,
+                    tx_incarnation: tx.incarnation,
+                }));
+            }
+        }
     }
 
     pub(crate) fn next_task(&self) -> Option<Task> {

--- a/tests/common/runner.rs
+++ b/tests/common/runner.rs
@@ -2,10 +2,9 @@ use alloy_primitives::Bloom;
 use alloy_rpc_types::Block;
 use pevm::{
     chain::{CalculateReceiptRootError, PevmChain, PevmEthereum},
-    EvmAccount, Pevm, Storage,
+    EvmAccount, ParallelParams, Pevm, PevmStrategy, Storage,
 };
 use revm::primitives::{alloy_primitives::U160, Address, BlockEnv, SpecId, TxEnv, U256};
-use std::{num::NonZeroUsize, thread};
 
 // Mock an account from an integer index that is used as the address.
 // Useful for mock iterations.
@@ -24,7 +23,6 @@ pub fn mock_account(idx: usize) -> (Address, EvmAccount) {
 // Execute an REVM block sequentially & with PEVM and assert that
 // the execution results match.
 pub fn test_execute_revm<S: Storage + Send + Sync>(storage: S, txs: Vec<TxEnv>) {
-    let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
     assert_eq!(
         pevm::execute_revm_sequential(
             &storage,
@@ -39,7 +37,7 @@ pub fn test_execute_revm<S: Storage + Send + Sync>(storage: S, txs: Vec<TxEnv>) 
             SpecId::LATEST,
             BlockEnv::default(),
             txs,
-            concurrency_level,
+            ParallelParams::default()
         ),
     );
 }
@@ -52,10 +50,14 @@ pub fn test_execute_alloy<S: Storage + Send + Sync, C: PevmChain + Send + Sync +
     block: Block<C::Transaction>,
     must_match_block_header: bool,
 ) {
-    let concurrency_level = thread::available_parallelism().unwrap_or(NonZeroUsize::MIN);
     let mut pevm = Pevm::default();
-    let sequential_result = pevm.execute(storage, chain, block.clone(), concurrency_level, true);
-    let parallel_result = pevm.execute(storage, chain, block.clone(), concurrency_level, false);
+    let sequential_result = pevm.execute(storage, chain, block.clone(), PevmStrategy::sequential());
+    let parallel_result = pevm.execute(
+        storage,
+        chain,
+        block.clone(),
+        PevmStrategy::auto(block.transactions.len(), block.header.gas_used),
+    );
     assert_eq!(&sequential_result, &parallel_result);
 
     let tx_results = sequential_result.unwrap();

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -11,7 +11,8 @@
 use ahash::AHashMap;
 use pevm::chain::PevmEthereum;
 use pevm::{
-    Bytecodes, EvmAccount, EvmCode, InMemoryStorage, Pevm, PevmError, PevmTxExecutionResult,
+    Bytecodes, EvmAccount, EvmCode, InMemoryStorage, ParallelParams, Pevm, PevmError,
+    PevmTxExecutionResult,
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use revm::db::PlainAccount;
@@ -27,9 +28,9 @@ use revme::cmd::statetest::{
     merkle_trie::{log_rlp_hash, state_merkle_trie_root},
     utils::recover_address,
 };
+use std::fs;
 use std::path::Path;
 use std::str::FromStr;
-use std::{fs, num::NonZeroUsize};
 use walkdir::{DirEntry, WalkDir};
 
 #[path = "../common/mod.rs"]
@@ -141,7 +142,7 @@ fn run_test_unit(path: &Path, unit: TestUnit) {
                     spec_name.to_spec_id(),
                     build_block_env(&unit.env),
                     vec![tx_env.unwrap()],
-                    NonZeroUsize::MIN,
+                    ParallelParams::default()
                 ),
             ) {
                 // EIP-2681


### PR DESCRIPTION
## Before
```
Average: x2.04
```

## After

```
Average: x2.09
Max: x4.57
Min: x0.86
```

## Idea

Instead of running 12 threads, we use 8 threads for regular txs and 8 threads for heavy txs (priority txs).

The "regular" threads run as normal (possibly execute priority txs).

The "priority" threads only find and execute the priority txs. They stop as soon as there are no more priority txs.