### PR TITLE
perf: replace `std` `HashMap` with `hashbrown` 15 & `ahash` with `rustc-hash` 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,7 +26,6 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
- "serde",
  "version_check",
  "zerocopy",
 ]
@@ -2778,7 +2777,6 @@ dependencies = [
 name = "pevm"
 version = "0.1.0"
 dependencies = [
- "ahash",
  "alloy-chains",
  "alloy-consensus",
  "alloy-primitives",
@@ -2795,6 +2793,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "flate2",
+ "hashbrown 0.15.0",
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
@@ -2804,6 +2803,7 @@ dependencies = [
  "revm",
  "revme",
  "rpmalloc",
+ "rustc-hash",
  "serde",
  "serde_json",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,6 @@ name = "fetch"
 path = "bin/fetch.rs"
 
 [dependencies]
-# Put this behind a feature flag if there are use cases & users
-# that need more security guarantees even for internally hashing
-# EVM memory locations (we do not persist these hashes).
-ahash = { version = "0.8.11", features = ["serde"] }
 alloy-chains = "0.1.40"
 alloy-consensus = "0.5.2"
 alloy-primitives = { version = "0.8.8", features = [
@@ -33,6 +29,8 @@ alloy-trie = "0.7.2"
 bitflags = "2.6.0"
 bitvec = "1.0.1"
 dashmap = "6.1.0"
+hashbrown = "0.15.0"
+rustc-hash = "2.0.0"
 serde = "1.0.210"
 smallvec = "1.13.2"
 thiserror = "1.0.64"

--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,6 +1,6 @@
 //! Chain specific utils
 
-use std::fmt::Debug;
+use std::{fmt::Debug, hash::BuildHasher};
 
 use alloy_primitives::B256;
 use alloy_rpc_types::{BlockTransactions, Header};
@@ -63,9 +63,9 @@ pub trait PevmChain: Debug {
     fn get_tx_env(&self, tx: Self::Transaction) -> Result<TxEnv, Self::TransactionParsingError>;
 
     /// Build [MvMemory]
-    fn build_mv_memory(
+    fn build_mv_memory<H: BuildHasher>(
         &self,
-        _hasher: &ahash::RandomState,
+        _hasher: &H,
         _block_env: &BlockEnv,
         txs: &[TxEnv],
     ) -> MvMemory {
@@ -80,7 +80,7 @@ pub trait PevmChain: Debug {
     ) -> Handler<'a, revm::Context<EXT, DB>, EXT, DB>;
 
     /// Get [RewardPolicy]
-    fn get_reward_policy(&self, hasher: &ahash::RandomState) -> RewardPolicy;
+    fn get_reward_policy<H: BuildHasher>(&self, hasher: &H) -> RewardPolicy;
 
     /// Calculate receipt root
     fn calculate_receipt_root(

--- a/src/chain/ethereum.rs
+++ b/src/chain/ethereum.rs
@@ -1,15 +1,13 @@
 //! Ethereum
 
-use std::{
-    collections::{BTreeMap, HashMap},
-    fmt::Debug,
-};
+use std::{collections::BTreeMap, fmt::Debug, hash::BuildHasher};
 
 use alloy_chains::NamedChain;
 use alloy_consensus::{ReceiptEnvelope, TxType};
 use alloy_primitives::{B256, U256};
 use alloy_provider::network::eip2718::Encodable2718;
 use alloy_rpc_types::{BlockTransactions, Header};
+use hashbrown::HashMap;
 use revm::{
     primitives::{AuthorizationList, BlockEnv, SpecId, TxEnv},
     Handler,
@@ -151,9 +149,9 @@ impl PevmChain for PevmEthereum {
         })
     }
 
-    fn build_mv_memory(
+    fn build_mv_memory<H: BuildHasher>(
         &self,
-        hasher: &ahash::RandomState,
+        hasher: &H,
         block_env: &BlockEnv,
         txs: &[TxEnv],
     ) -> MvMemory {
@@ -178,7 +176,7 @@ impl PevmChain for PevmEthereum {
         Handler::mainnet_with_spec(spec_id, with_reward_beneficiary)
     }
 
-    fn get_reward_policy(&self, _hasher: &ahash::RandomState) -> RewardPolicy {
+    fn get_reward_policy<H: BuildHasher>(&self, _hasher: &H) -> RewardPolicy {
         RewardPolicy::Ethereum
     }
 

--- a/src/chain/optimism.rs
+++ b/src/chain/optimism.rs
@@ -1,10 +1,11 @@
 //! Optimism
-use std::collections::{BTreeMap, HashMap};
+use std::{collections::BTreeMap, hash::BuildHasher};
 
 use alloy_chains::NamedChain;
 use alloy_consensus::{Signed, TxEip1559, TxEip2930, TxEip7702, TxLegacy};
 use alloy_primitives::{Bytes, B256, U256};
 use alloy_rpc_types::{BlockTransactions, Header};
+use hashbrown::HashMap;
 use op_alloy_consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType, TxDeposit};
 use op_alloy_network::eip2718::Encodable2718;
 use revm::{
@@ -156,9 +157,9 @@ impl PevmChain for PevmOptimism {
         }
     }
 
-    fn build_mv_memory(
+    fn build_mv_memory<H: BuildHasher>(
         &self,
-        hasher: &ahash::RandomState,
+        hasher: &H,
         block_env: &BlockEnv,
         txs: &[TxEnv],
     ) -> MvMemory {
@@ -207,7 +208,7 @@ impl PevmChain for PevmOptimism {
         Handler::optimism_with_spec(spec_id, with_reward_beneficiary)
     }
 
-    fn get_reward_policy(&self, hasher: &ahash::RandomState) -> RewardPolicy {
+    fn get_reward_policy<H: BuildHasher>(&self, hasher: &H) -> RewardPolicy {
         RewardPolicy::Optimism {
             l1_fee_recipient_location_hash: hasher
                 .hash_one(MemoryLocation::Basic(revm::optimism::L1_FEE_RECIPIENT)),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 
 // TODO: Better types & API for third-party integration
 
-use std::collections::HashMap;
 use std::hash::{BuildHasherDefault, Hasher};
 
 use alloy_primitives::{Address, B256, U256};
 use bitflags::bitflags;
+use hashbrown::HashMap;
 use smallvec::SmallVec;
 
 /// We use the last 8 bytes of an existing hash like address

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,8 +1,8 @@
-use std::{collections::HashMap, fmt::Display, sync::Arc};
+use std::{fmt::Display, sync::Arc};
 
-use ahash::AHashMap;
 use alloy_primitives::{Address, Bytes, B256, U256};
 use bitvec::vec::BitVec;
+use hashbrown::HashMap;
 use revm::{
     interpreter::analysis::to_analysed,
     primitives::{
@@ -11,6 +11,7 @@ use revm::{
     },
     DatabaseRef,
 };
+use rustc_hash::FxBuildHasher;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -33,7 +34,7 @@ pub struct EvmAccount {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub code: Option<EvmCode>,
     /// The account's storage.
-    pub storage: AHashMap<U256, U256>,
+    pub storage: HashMap<U256, U256, FxBuildHasher>,
 }
 
 impl From<Account> for EvmAccount {

--- a/src/storage/rpc.rs
+++ b/src/storage/rpc.rs
@@ -3,7 +3,6 @@
 
 use std::{fmt::Debug, future::IntoFuture, sync::Mutex, time::Duration};
 
-use ahash::AHashMap;
 use alloy_primitives::{Address, B256, U256};
 use alloy_provider::{
     network::{BlockResponse, HeaderResponse},
@@ -12,6 +11,7 @@ use alloy_provider::{
 use alloy_rpc_types::{BlockId, BlockNumberOrTag};
 use alloy_transport::TransportError;
 use alloy_transport_http::Http;
+use hashbrown::HashMap;
 use reqwest::Client;
 use revm::{
     precompile::{PrecompileSpecId, Precompiles},
@@ -150,7 +150,7 @@ impl<N: Network> Storage for RpcStorage<N> {
                 nonce,
                 code_hash,
                 code: None,
-                storage: AHashMap::default(),
+                storage: HashMap::default(),
             },
         );
         Ok(Some(AccountBasic { balance, nonce }))

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     fs::{self, File},
     io::BufReader,
 };
@@ -7,7 +6,10 @@ use std::{
 use alloy_primitives::{uint, Address, Bloom, Bytes, B256, U256};
 use alloy_rpc_types::{Block, BlockTransactions, Header, Signature};
 use flate2::bufread::GzDecoder;
-use pevm::{chain::PevmChain, BlockHashes, Bytecodes, EvmAccount, InMemoryStorage};
+use hashbrown::HashMap;
+use pevm::{
+    chain::PevmChain, BlockHashes, BuildSuffixHasher, Bytecodes, EvmAccount, InMemoryStorage,
+};
 
 pub mod runner;
 pub use runner::{mock_account, test_execute_alloy, test_execute_revm};
@@ -69,10 +71,11 @@ pub fn for_each_block_from_disk(mut handler: impl FnMut(Block, InMemoryStorage))
         .unwrap();
 
         // Parse state
-        let accounts: HashMap<Address, EvmAccount> = serde_json::from_reader(BufReader::new(
-            File::open(format!("data/blocks/{block_number}/pre_state.json")).unwrap(),
-        ))
-        .unwrap();
+        let accounts: HashMap<Address, EvmAccount, BuildSuffixHasher> =
+            serde_json::from_reader(BufReader::new(
+                File::open(format!("data/blocks/{block_number}/pre_state.json")).unwrap(),
+            ))
+            .unwrap();
 
         // Parse block hashes
         let block_hashes: BlockHashes =

--- a/tests/common/storage.rs
+++ b/tests/common/storage.rs
@@ -1,17 +1,18 @@
-use ahash::AHashMap;
+use hashbrown::HashMap;
 use revm::primitives::{
     alloy_primitives::U160, keccak256, ruint::UintTryFrom, Address, B256, I256, U256,
 };
+use rustc_hash::FxBuildHasher;
 
 #[derive(Debug, Default)]
 pub struct StorageBuilder {
-    dict: AHashMap<U256, U256>,
+    dict: HashMap<U256, U256, FxBuildHasher>,
 }
 
 impl StorageBuilder {
     pub fn new() -> Self {
         StorageBuilder {
-            dict: AHashMap::default(),
+            dict: HashMap::default(),
         }
     }
 
@@ -47,7 +48,7 @@ impl StorageBuilder {
         *entry = buffer.into();
     }
 
-    pub fn build(self) -> AHashMap<U256, U256> {
+    pub fn build(self) -> HashMap<U256, U256, FxBuildHasher> {
         self.dict
     }
 }

--- a/tests/erc20/contract.rs
+++ b/tests/erc20/contract.rs
@@ -1,9 +1,9 @@
 use crate::common::storage::{from_address, from_indices, from_short_string, StorageBuilder};
-use ahash::AHashMap;
-use pevm::EvmAccount;
+use pevm::{BuildSuffixHasher, EvmAccount};
 use revm::primitives::{
-    fixed_bytes, hex::FromHex, ruint::UintTryFrom, Address, Bytecode, Bytes, B256, U256,
+    fixed_bytes, hex::FromHex, ruint::UintTryFrom, Address, Bytecode, Bytes, HashMap, B256, U256,
 };
+use rustc_hash::FxBuildHasher;
 
 const ERC20_TOKEN: &str = include_str!("./assets/ERC20Token.hex");
 
@@ -14,8 +14,8 @@ pub struct ERC20Token {
     symbol: String,
     decimals: U256,
     initial_supply: U256,
-    balances: AHashMap<Address, U256>,
-    allowances: AHashMap<(Address, Address), U256>,
+    balances: HashMap<Address, U256, BuildSuffixHasher>,
+    allowances: HashMap<(Address, Address), U256, FxBuildHasher>,
 }
 
 impl ERC20Token {
@@ -29,8 +29,8 @@ impl ERC20Token {
             symbol: String::from(symbol),
             decimals: U256::from(decimals),
             initial_supply: U256::from(initial_supply),
-            balances: AHashMap::new(),
-            allowances: AHashMap::new(),
+            balances: HashMap::default(),
+            allowances: HashMap::default(),
         }
     }
 

--- a/tests/erc20/main.rs
+++ b/tests/erc20/main.rs
@@ -8,10 +8,9 @@ pub mod common;
 #[path = "./mod.rs"]
 pub mod erc20;
 
-use ahash::AHashMap;
 use common::test_execute_revm;
 use erc20::generate_cluster;
-use pevm::{Bytecodes, EvmAccount, InMemoryStorage};
+use pevm::{Bytecodes, ChainState, EvmAccount, InMemoryStorage};
 use revm::primitives::{Address, TxEnv};
 
 #[test]
@@ -29,7 +28,8 @@ fn erc20_clusters() {
     const NUM_PEOPLE_PER_FAMILY: usize = 15;
     const NUM_TRANSFERS_PER_PERSON: usize = 15;
 
-    let mut final_state = AHashMap::from([(Address::ZERO, EvmAccount::default())]); // Beneficiary
+    let mut final_state = ChainState::default();
+    final_state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     let mut final_bytecodes = Bytecodes::default();
     let mut final_txs = Vec::<TxEnv>::new();
     for _ in 0..NUM_CLUSTERS {

--- a/tests/ethereum/main.rs
+++ b/tests/ethereum/main.rs
@@ -8,10 +8,10 @@
 // - We use custom handlers (for lazy-updating the beneficiary account, etc.) that require "re-testing".
 // - Help outline the minimal state commitment logic for pevm.
 
-use ahash::AHashMap;
 use pevm::chain::PevmEthereum;
 use pevm::{
-    Bytecodes, EvmAccount, EvmCode, InMemoryStorage, Pevm, PevmError, PevmTxExecutionResult,
+    Bytecodes, ChainState, EvmAccount, EvmCode, InMemoryStorage, Pevm, PevmError,
+    PevmTxExecutionResult,
 };
 use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, ParallelIterator};
 use revm::db::PlainAccount;
@@ -121,7 +121,7 @@ fn run_test_unit(path: &Path, unit: TestUnit) {
                 return;
             }
 
-            let mut chain_state = AHashMap::new();
+            let mut chain_state = ChainState::default();
             let mut bytecodes = Bytecodes::default();
             for (address, raw_info) in unit.pre.iter() {
                 let code = Bytecode::new_raw(raw_info.code.clone());

--- a/tests/mixed.rs
+++ b/tests/mixed.rs
@@ -1,7 +1,6 @@
 // Test raw transfers -- A block with random raw transfers, ERC-20 transfers, and Uniswap swaps.
 
-use ahash::AHashMap;
-use pevm::{Bytecodes, EvmAccount, InMemoryStorage};
+use pevm::{Bytecodes, ChainState, EvmAccount, InMemoryStorage};
 use rand::random;
 use revm::primitives::{env::TxEnv, Address, TransactTo, U256};
 
@@ -15,7 +14,7 @@ fn mixed_block() {
 
     // TODO: Run a few times
     let mut block_size = 0;
-    let mut final_state = AHashMap::new();
+    let mut final_state = ChainState::default();
     final_state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     let mut final_bytecodes = Bytecodes::default();
     let mut final_txs = Vec::new();

--- a/tests/uniswap/contract.rs
+++ b/tests/uniswap/contract.rs
@@ -1,13 +1,14 @@
 use crate::common::storage::{
     from_address, from_indices, from_short_string, from_tick, StorageBuilder,
 };
-use ahash::AHashMap;
+use hashbrown::HashMap;
 use pevm::EvmAccount;
 use revm::primitives::{
     fixed_bytes,
     hex::{FromHex, ToHexExt},
     keccak256, uint, Address, Bytecode, Bytes, FixedBytes, B256, U256,
 };
+use rustc_hash::FxBuildHasher;
 
 const POOL_FEE: u32 = 3000;
 const TICK_SPACING: i32 = 60;
@@ -63,14 +64,14 @@ impl WETH9 {
 #[derive(Debug, Default)]
 pub struct UniswapV3Factory {
     owner: Address,
-    pools: AHashMap<(Address, Address, U256), Address>,
+    pools: HashMap<(Address, Address, U256), Address, FxBuildHasher>,
 }
 
 impl UniswapV3Factory {
     pub fn new(owner: Address) -> Self {
         Self {
             owner,
-            pools: AHashMap::new(),
+            pools: HashMap::default(),
         }
     }
 
@@ -143,9 +144,9 @@ pub struct UniswapV3Pool {
     token_0: Address,
     token_1: Address,
     factory: Address,
-    positions: AHashMap<U256, [U256; 4]>,
-    ticks: AHashMap<U256, [U256; 4]>,
-    tick_bitmap: AHashMap<U256, U256>,
+    positions: HashMap<U256, [U256; 4], FxBuildHasher>,
+    ticks: HashMap<U256, [U256; 4], FxBuildHasher>,
+    tick_bitmap: HashMap<U256, U256, FxBuildHasher>,
 }
 
 impl UniswapV3Pool {
@@ -154,9 +155,9 @@ impl UniswapV3Pool {
             token_0,
             token_1,
             factory,
-            positions: AHashMap::new(),
-            ticks: AHashMap::new(),
-            tick_bitmap: AHashMap::new(),
+            positions: HashMap::default(),
+            ticks: HashMap::default(),
+            tick_bitmap: HashMap::default(),
         }
     }
 

--- a/tests/uniswap/main.rs
+++ b/tests/uniswap/main.rs
@@ -12,8 +12,7 @@ pub mod erc20;
 pub mod uniswap;
 
 use crate::uniswap::generate_cluster;
-use ahash::AHashMap;
-use pevm::{Bytecodes, EvmAccount, InMemoryStorage};
+use pevm::{Bytecodes, ChainState, EvmAccount, InMemoryStorage};
 use revm::primitives::{Address, TxEnv};
 
 #[test]
@@ -22,7 +21,8 @@ fn uniswap_clusters() {
     const NUM_PEOPLE_PER_CLUSTER: usize = 20;
     const NUM_SWAPS_PER_PERSON: usize = 20;
 
-    let mut final_state = AHashMap::from([(Address::ZERO, EvmAccount::default())]); // Beneficiary
+    let mut final_state = ChainState::default();
+    final_state.insert(Address::ZERO, EvmAccount::default()); // Beneficiary
     let mut final_bytecodes = Bytecodes::default();
     let mut final_txs = Vec::<TxEnv>::new();
     for _ in 0..NUM_CLUSTERS {


### PR DESCRIPTION
A new `HashMap` now should be imported from `hashbrown` and explicitly declared a hasher (`BuildIdentityHasher`, `BuildSuffixHasher`, or `FxBuildHasher` as the default).