### PR TITLE
chore: store FxBuildHasher by value

### DIFF
--- a/src/pevm.rs
+++ b/src/pevm.rs
@@ -159,7 +159,7 @@ impl Pevm {
 
         let mv_memory = chain.build_mv_memory(&self.hasher, &block_env, &txs);
         let vm = Vm::new(
-            &self.hasher,
+            self.hasher,
             storage,
             &mv_memory,
             chain,

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -497,7 +497,7 @@ impl<'a, S: Storage, C: PevmChain> Database for VmDb<'a, S, C> {
 }
 
 pub(crate) struct Vm<'a, S: Storage, C: PevmChain> {
-    hasher: &'a FxBuildHasher,
+    hasher: FxBuildHasher,
     storage: &'a S,
     mv_memory: &'a MvMemory,
     chain: &'a C,
@@ -510,7 +510,7 @@ pub(crate) struct Vm<'a, S: Storage, C: PevmChain> {
 
 impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
     pub(crate) fn new(
-        hasher: &'a FxBuildHasher,
+        hasher: FxBuildHasher,
         storage: &'a S,
         mv_memory: &'a MvMemory,
         chain: &'a C,
@@ -527,7 +527,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
             txs,
             spec_id,
             beneficiary_location_hash: hasher.hash_one(MemoryLocation::Basic(block_env.coinbase)),
-            reward_policy: chain.get_reward_policy(hasher),
+            reward_policy: chain.get_reward_policy(&hasher),
         }
     }
 


### PR DESCRIPTION
`FxBuildHasher` is a ZST, there is no benefit to storing it by reference; even if it was something like a random state it would hold 1 or 2 u64s, which should still be copied rather than passed by reference