### PR TITLE
bench: Relax the gas limit for mock transactions in gigagas bench

### DIFF
--- a/tests/erc20/mod.rs
+++ b/tests/erc20/mod.rs
@@ -4,7 +4,8 @@ use contract::ERC20Token;
 use pevm::{Bytecodes, ChainState, EvmAccount};
 use revm::primitives::{uint, Address, TransactTo, TxEnv, U256};
 
-pub const GAS_LIMIT: u64 = 26_938;
+pub const GAS_LIMIT: u64 = 35_000;
+pub const ESTIMATED_GAS_USED: u64 = 29_738;
 
 // TODO: Better randomness control. Sometimes we want duplicates to test
 // dependent transactions, sometimes we want to guarantee non-duplicates

--- a/tests/uniswap/mod.rs
+++ b/tests/uniswap/mod.rs
@@ -5,7 +5,8 @@ use contract::{SingleSwap, SwapRouter, UniswapV3Factory, UniswapV3Pool, WETH9};
 use pevm::{Bytecodes, ChainState, EvmAccount};
 use revm::primitives::{fixed_bytes, uint, Address, Bytes, TransactTo, TxEnv, B256, U256};
 
-pub const GAS_LIMIT: u64 = 155_934;
+pub const GAS_LIMIT: u64 = 200_000;
+pub const ESTIMATED_GAS_USED: u64 = 155_934;
 
 pub fn generate_cluster(
     num_people: usize,


### PR DESCRIPTION
In gigagas bench, many transactions do not complete but instead exit with an OutOfGas error, which may lead to inaccurate bench results. For raw transfers, the issue is due to the duplication of mock account addresses and built-in precompiled contract account addresses, resulting in OutOfGas errors or errors in precompiles. ERC20 transfers and Uniswap swaps are failing midway due to the gas limit being set too low, causing most transactions to exit due to OutOfGas. We have found that the gas limit needs to be set larger than the actual gas used for some transactions to complete successfully. This is because during the execution process of the revm interpreter, the gas consumed is actually equal to gas used + gas refunded, and when the contract code uses the sstore instruction, it is required by https://eips.ethereum.org/EIPS/eip-1706 that the gas left must be >= stipend (2300) when running this instruction.
In this PR, we have relaxed the gas limit by referencing the gas expenses required for the complete execution of the transaction, so that each transaction in the bench can successfully complete.