### PR TITLE
feat: downgrade deps to make it compatible to reth 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -59,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42642aed67f938363d9c7543e5ca4163cfb4205d9ec15fe933dc4e865d2932dd"
+checksum = "705687d5bfd019fee57cf9e206b27b30a9a9617535d5590a02b171e813208f8e"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -86,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.2.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeffd2590ce780ddfaa9d0ae340eb2b4e08627650c4676eef537cef0b4bf535d"
+checksum = "ea59dc42102bc9a1905dc57901edc6dd48b9f38115df86c7d252acba70d71d04"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -98,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fbc52a30df46f9831ed74557dfad0d94b12420393662a8b9ef90e2d6c8cb4b0"
+checksum = "6ffb906284a1e1f63c4607da2068c8197458a352d0b3e9796e67353d72a9be85"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -116,9 +115,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d55a16a5f9ca498a217c060414bcd1c43e934235dc8058b31b87dcd69ff4f105"
+checksum = "f8fa8a1a3c4cbd221f2b8e3693aeb328fca79a757fe556ed08e47bbbc2a70db7"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -130,9 +129,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d236a8c3e1d5adc09b1b63c81815fc9b757d9a4ba9482cc899f9679b55dd437"
+checksum = "85fa23a6a9d612b52e402c995f2d582c25165ec03ac6edf64c861a76bc5b87cd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -151,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd15a0990fa8a56d85a42d6a689719aa4eebf5e2f1a5c5354658c0bfc52cac9a"
+checksum = "801492711d4392b2ccf5fc0bc69e299fa1aab15167d74dcaa9aab96a54f684bd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -192,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316f522bb6f9ac3805132112197957013b570e20cfdad058e8339dae6030c849"
+checksum = "fcfaa4ffec0af04e3555686b8aacbcdf7d13638133a0672749209069750f78a6"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -214,17 +213,14 @@ dependencies = [
  "futures",
  "futures-utils-wasm",
  "lru",
- "parking_lot",
  "pin-project",
  "reqwest 0.12.8",
- "schnellru",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
@@ -251,9 +247,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b2ab59712c594c9624aaa69e38e4d38f180cb569f1fa46cdaf8c21fd50793e5"
+checksum = "370143ed581aace6e663342d21d209c6b2e34ee6142f7d6675adb518deeaf0dc"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -269,14 +265,13 @@ dependencies = [
  "tower",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba21284319e12d053baa204d438db6c1577aedd94c1298e4becefdac1f9cec87"
+checksum = "9ffc534b7919e18f35e3aa1f507b6f3d9d92ec298463a9f6beaac112809d8d06"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-engine",
@@ -287,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44848fced3b42260b9cb61f22102246636dfe5a2d0132f8d10a617df3cb1a74b"
+checksum = "e0285c4c09f838ab830048b780d7f4a4f460f309aa1194bb049843309524c64c"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -305,9 +300,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35894711990019fafff0012b82b9176cbb744516eb2a9bbe6b8e5cae522163ee"
+checksum = "413f4aa3ccf2c3e4234a047c5fa4727916d7daf25a89f9b765df0ba09784fd87"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -324,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2843c195675f06b29c09a4315cccdc233ab5bdc7c0a3775909f9f0cab5e9ae0f"
+checksum = "9dff0ab1cdd43ca001e324dc27ee0e8606bd2161d6623c63e0e0b8c4dfc13600"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -335,9 +330,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88b2a00d9803dfef99963303ffe41a7bf2221f3342f0a503d6741a9f4a18e5e5"
+checksum = "2fd4e0ad79c81a27ca659be5d176ca12399141659fef2bcbfdc848da478f4504"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -407,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc2c8f6b8c227ef0398f702d954c4ab572c2ead3c1ed4a5157aa1cbaf959747"
+checksum = "2ac3e97dad3d31770db0fc89bd6a63b789fbae78963086733f960cf32c483904"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -422,14 +417,13 @@ dependencies = [
  "tower",
  "tracing",
  "url",
- "wasmtimer",
 ]
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.5.2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd328e990d57f4c4e63899fb2c26877597d6503f8e0022a3d71b2d753ecbfc0c"
+checksum = "b367dcccada5b28987c2296717ee04b9a5637aacd78eacb1726ef211678b5212"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -442,13 +436,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.7.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd7f8b3a7c65ca09b3c7bdd7c7d72d7423d026f5247eda96af53d24e58315c1"
+checksum = "e9703ce68b97f8faae6f7739d1e003fc97621b856953cbcdbb2b515743f23288"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more 1.0.0",
  "nybbles",
  "serde",
@@ -1827,15 +1820,13 @@ checksum = "d23bd4e7b5eda0d0f3a307e8b381fdc8ba9000f26fbe912250c0a4cc3956364a"
 
 [[package]]
 name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-
-[[package]]
-name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2556,9 +2547,9 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d49163f952491820088dd0e66f3a35d63337c3066eceff0a931bf83a8e2101"
+checksum = "7ea7162170c6f3cad8f67f4dd7108e3f78349fd553da5b8bebff1e7ef8f38896"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2572,9 +2563,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-network"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ff1ea317441b9eb6317b24d13f9088e3b14ef48b15bfb6a125ca404df036d8"
+checksum = "d113b325527ba7da271a8793f1c14bdf7f035ce9e0611e668c36fc6812568c7f"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -2586,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.5.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9556293835232b019ec9c6fd84e4265a3151111af60ea09b5b513e3dbed41c"
+checksum = "323c65880e2561aa87f74f8af260fd15b9cc930c448c88a60ae95af86c88c634"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2706,16 +2697,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
 ]
 
 [[package]]
@@ -3242,8 +3223,8 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "16.0.0"
-source = "git+https://github.com/risechain/revm?rev=bb350a971e5f39a8f822ace081584a3a45fd7c6a#bb350a971e5f39a8f822ace081584a3a45fd7c6a"
+version = "14.0.3"
+source = "git+https://github.com/risechain/revm?rev=fa685fbacc56718bdcc8aa11f851e5070c2d63b3#fa685fbacc56718bdcc8aa11f851e5070c2d63b3"
 dependencies = [
  "auto_impl",
  "cfg-if",
@@ -3260,8 +3241,8 @@ dependencies = [
 
 [[package]]
 name = "revm-interpreter"
-version = "12.0.0"
-source = "git+https://github.com/risechain/revm?rev=bb350a971e5f39a8f822ace081584a3a45fd7c6a#bb350a971e5f39a8f822ace081584a3a45fd7c6a"
+version = "10.0.3"
+source = "git+https://github.com/risechain/revm?rev=fa685fbacc56718bdcc8aa11f851e5070c2d63b3#fa685fbacc56718bdcc8aa11f851e5070c2d63b3"
 dependencies = [
  "revm-primitives",
  "serde",
@@ -3269,8 +3250,8 @@ dependencies = [
 
 [[package]]
 name = "revm-precompile"
-version = "13.0.0"
-source = "git+https://github.com/risechain/revm?rev=bb350a971e5f39a8f822ace081584a3a45fd7c6a#bb350a971e5f39a8f822ace081584a3a45fd7c6a"
+version = "11.0.3"
+source = "git+https://github.com/risechain/revm?rev=fa685fbacc56718bdcc8aa11f851e5070c2d63b3#fa685fbacc56718bdcc8aa11f851e5070c2d63b3"
 dependencies = [
  "aurora-engine-modexp",
  "blst",
@@ -3288,8 +3269,8 @@ dependencies = [
 
 [[package]]
 name = "revm-primitives"
-version = "12.0.0"
-source = "git+https://github.com/risechain/revm?rev=bb350a971e5f39a8f822ace081584a3a45fd7c6a#bb350a971e5f39a8f822ace081584a3a45fd7c6a"
+version = "10.0.0"
+source = "git+https://github.com/risechain/revm?rev=fa685fbacc56718bdcc8aa11f851e5070c2d63b3#fa685fbacc56718bdcc8aa11f851e5070c2d63b3"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
@@ -3307,11 +3288,12 @@ dependencies = [
 
 [[package]]
 name = "revme"
-version = "1.0.0"
-source = "git+https://github.com/risechain/revm?rev=bb350a971e5f39a8f822ace081584a3a45fd7c6a#bb350a971e5f39a8f822ace081584a3a45fd7c6a"
+version = "0.10.3"
+source = "git+https://github.com/risechain/revm?rev=fa685fbacc56718bdcc8aa11f851e5070c2d63b3#fa685fbacc56718bdcc8aa11f851e5070c2d63b3"
 dependencies = [
  "alloy-rlp",
  "hash-db",
+ "hashbrown 0.14.5",
  "hex",
  "indicatif",
  "k256",
@@ -3630,17 +3612,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01227be5826fa0690321a2ba6c5cd57a19cf3f6a09e76973b58e61de6ab9d1c1"
 dependencies = [
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "schnellru"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a8ef13a93c54d20580de1e5c413e624e53121d42fc7e2c11d10ef7f8b02367"
-dependencies = [
- "ahash",
- "cfg-if",
- "hashbrown 0.13.2",
 ]
 
 [[package]]
@@ -4696,20 +4667,6 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
-
-[[package]]
-name = "wasmtimer"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7ed9d8b15c7fb594d72bfb4b5a276f3d2029333cd93a932f376f5937f6f80ee"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot",
- "pin-utils",
- "slab",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "web-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ path = "bin/fetch.rs"
 
 [dependencies]
 alloy-chains = "0.1.40"
-alloy-consensus = "0.5.2"
-alloy-primitives = { version = "0.8.8", features = [
+alloy-consensus = "0.4.2"
+alloy-primitives = { version = "0.8.7", features = [
     "asm-keccak",
     "map-fxhash",
 ] }
-alloy-rlp = "0.3.8"
-alloy-rpc-types = "0.5.2"
-alloy-trie = "0.7.2"
+alloy-rlp = "0.3.4"
+alloy-rpc-types = "0.4.2"
+alloy-trie = "0.6"
 # We can roll our own but [revm] depends on this anyway.
 bitflags = "2.6.0"
 bitvec = "1.0.1"
@@ -36,16 +36,16 @@ smallvec = "1.13.2"
 thiserror = "1.0.64"
 
 # Let's do our best to port needed REVM changes upstream
-revm = { git = "https://github.com/risechain/revm", rev = "bb350a971e5f39a8f822ace081584a3a45fd7c6a", features = [
+revm = { git = "https://github.com/risechain/revm", rev = "fa685fbacc56718bdcc8aa11f851e5070c2d63b3", features = [
     "serde",
 ] }
 
 # RPC Storage dependencies
 # TODO: Put these behind an RPC flag to not pollute the core
 # library with RPC network & transport dependencies, etc.
-alloy-provider = "0.5.2"
-alloy-transport = "0.5.2"
-alloy-transport-http = "0.5.2"
+alloy-provider = "0.4.2"
+alloy-transport = "0.4.2"
+alloy-transport-http = "0.4.2"
 reqwest = "0.12.8"
 tokio = { version = "1.40.0", features = ["rt-multi-thread"] }
 
@@ -56,15 +56,15 @@ flate2 = "1.0.34"
 serde_json = { version = "1.0.132", features = ["preserve_order"] }
 
 # OP dependencies
-op-alloy-consensus = { version = "0.5.0", optional = true }
-op-alloy-network = { version = "0.5.0", optional = true }
-op-alloy-rpc-types = { version = "0.5.0", optional = true }
+op-alloy-consensus = { version = "0.4.0", optional = true }
+op-alloy-network = { version = "0.4.0", optional = true }
+op-alloy-rpc-types = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.5.1"
 rand = "0.8.5"
 rayon = "1.10.0"
-revme = { git = "https://github.com/risechain/revm", rev = "bb350a971e5f39a8f822ace081584a3a45fd7c6a" }
+revme = { git = "https://github.com/risechain/revm", rev = "fa685fbacc56718bdcc8aa11f851e5070c2d63b3" }
 rpmalloc = { version = "0.2.2", features = ["thread_cache", "global_cache"] }
 snmalloc-rs = "0.3.6"
 tikv-jemallocator = "0.6.0"

--- a/src/chain/optimism.rs
+++ b/src/chain/optimism.rs
@@ -94,7 +94,7 @@ pub(crate) fn get_optimism_fields(
         OpTxType::Legacy => Signed::<TxLegacy>::try_from(inner).map(OpTxEnvelope::from),
         OpTxType::Eip2930 => Signed::<TxEip2930>::try_from(inner).map(OpTxEnvelope::from),
         OpTxType::Eip1559 => Signed::<TxEip1559>::try_from(inner).map(OpTxEnvelope::from),
-        OpTxType::Eip7702 => Signed::<TxEip7702>::try_from(inner).map(OpTxEnvelope::from),
+        OpTxType::Eip7702 => Signed::<TxEip7702>::try_from(inner).map(OpTxEnvelope::Eip7702),
         OpTxType::Deposit => {
             let tx_deposit = TxDeposit {
                 source_hash: tx

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -41,7 +41,7 @@ pub static MOCK_ALLOY_BLOCK_HEADER: Header = Header {
     withdrawals_root: None,
     blob_gas_used: None,
     parent_beacon_block_root: None,
-    requests_hash: None,
+    requests_root: None,
 };
 
 const MOCK_SIGNATURE: Signature = Signature {


### PR DESCRIPTION
We need these changes to make sure there is only one version of `alloy-eip7702` in the reth integration. Otherwise, there will be compile errors.

```diff
- op-alloy-consensus = { version = "0.5.0", optional = true }
- op-alloy-network = { version = "0.5.0", optional = true }
- op-alloy-rpc-types = { version = "0.5.0", optional = true }
+ op-alloy-consensus = { version = "0.4.0", optional = true }
+ op-alloy-network = { version = "0.4.0", optional = true }
+ op-alloy-rpc-types = { version = "0.4.0", optional = true }
```

This change is to update `revm` to the [`reth` branch](https://github.com/risechain/revm/commits/reth):
```diff
- revm = { git = "https://github.com/risechain/revm", rev = "bb350a971e5f39a8f822ace081584a3a45fd7c6a", features = [
+ revm = { git = "https://github.com/risechain/revm", rev = "fa685fbacc56718bdcc8aa11f851e5070c2d63b3", features = [
```

The other changes are just to make the code compiles.

-----

Yes, the target branch of this PR is [reth-integration-2](https://github.com/risechain/pevm/tree/reth-integration-2) because those changes are not needed on `main`.

PS: Actually, if we want, we can keep `op-alloy-*` changes on `main` branch and `revm` change on this branch (i.e. split this PR into two PRs). We can do that to keep this branch minimal.