### PR TITLE
doc(bench): demystify poor benchmark on new Linux kernel versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,6 @@ While others embed their parallel executor directly into their nodes, we built t
 
 ## Development
 
-> :warning: **Warning**
-> pevm is performing poorly in recent Linux kernel versions. We noticed huge performance degradation after updating a machine to Ubuntu 24.04 with Linux kernel 6.8. The current suspect is the new EEVDF scheduler, which does not go well with pevm's scheduler & thread management. Until we fully fix the issue, it is advised to **build and run pevm on Linux kernel 6.5**.
-
 - Install [cmake](https://cmake.org) to build `snmalloc` (a highly performant memory allocator).
 
 ```sh

--- a/crates/pevm/benches/README.md
+++ b/crates/pevm/benches/README.md
@@ -5,7 +5,9 @@ We use [criterion.rs](https://github.com/bheisler/criterion.rs) to benchmark 100
 For simplicity, we load the chain state into memory before execution. **In practice**, programs load chain states from disk with some in-memory cache, which **increases speedup for parallel execution** as disk I/O only blocks the reading thread, while other threads still execute and validate with in-memory data. On the other hand, sequential execution is completely blocked every time it reads new data from the disk.
 
 > :warning: **Warning**
-> pevm is performing poorly in recent Linux kernel versions. We noticed huge performance degradation after updating a machine to Ubuntu 24.04 with Linux kernel 6.8. The current suspect is the new EEVDF scheduler which doesn't go well with pevm's scheduler & thread management. Until we fully fix the issue, it is advised to **build and run pevm on Linux kernel 6.5**.
+> Micro-benchmarking multithreaded programs is rather nuanced. For maximal accuracy, ensure no heavy processes are running in the background and the benchmark machine is run in high-performance (as opposed to power-saving) mode. If the benchmark machine has more performance cores than the concurrency level (typically 8-12 for Ethereum mainnet blocks), it is best to benchmark with only performance cores like with:
+> `$ taskset -c -a 0-15 cargo bench --features global-alloc --bench mainnet`
+> Mixing efficient cores can degrade speedup by over 25%.
 
 The tables below were produced on a `c7g.8xlarge` EC2 instance with Graviton3 (32 vCPUs @2.6 GHz).
 

--- a/crates/pevm/benches/mainnet.rs
+++ b/crates/pevm/benches/mainnet.rs
@@ -12,7 +12,7 @@ use pevm::{chain::PevmEthereum, Pevm};
 #[path = "../tests/common/mod.rs"]
 pub mod common;
 
-// [rpmalloc] is generally better but can crash on AWS Graviton.
+// [rpmalloc] is generally better but can crash on ARM.
 #[cfg(feature = "global-alloc")]
 #[cfg(target_arch = "aarch64")]
 #[global_allocator]


### PR DESCRIPTION
We didn't reproduce the poor benchmark on cloud ARM instances. It turns out to only happen on machines with both performance and efficient cores like my Intel i9-12900K (Alder Lake and hybrid architecture in general). 

The kernel scheduler aggressively scheduled `pevm` worker threads on performance cores before 6.6, but the new scheduler (probably together with Intel driver changes) started to also pick efficient cores. The "fix" is to run the benchmark with `taskset -a -c` only performance cores.

Practically, we should run benchmarks (and performance-critical production code) on machines with all performance cores to not risk the kernel scheduler picking the "wrong" CPU to run a worker thread. 

A more guaranteed solution is to pin worker threads to performance cores right within `pevm`, but there seems to be no easy & cheap way to do it in Rust. `core_affinity` only pins a thread to a CPU, not a range. 