### PR TITLE
Fix spelling errors

### DIFF
--- a/crates/pevm/src/chain/ethereum.rs
+++ b/crates/pevm/src/chain/ethereum.rs
@@ -12,7 +12,7 @@ use revm::{
 
 use super::{CalculateReceiptRootError, PevmChain, RewardPolicy};
 use crate::{
-    hash_determinisitic, mv_memory::MvMemory, BuildIdentityHasher, MemoryLocation,
+    hash_deterministic, mv_memory::MvMemory, BuildIdentityHasher, MemoryLocation,
     PevmTxExecutionResult, TxIdx,
 };
 
@@ -127,7 +127,7 @@ impl PevmChain for PevmEthereum {
     fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[TxEnv]) -> MvMemory {
         let block_size = txs.len();
         let beneficiary_location_hash =
-            hash_determinisitic(MemoryLocation::Basic(block_env.coinbase));
+            hash_deterministic(MemoryLocation::Basic(block_env.coinbase));
 
         // TODO: Estimate more locations based on sender, to, etc.
         let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());

--- a/crates/pevm/src/chain/optimism.rs
+++ b/crates/pevm/src/chain/optimism.rs
@@ -13,7 +13,7 @@ use revm::{
 };
 
 use crate::{
-    hash_determinisitic, mv_memory::MvMemory, BuildIdentityHasher, MemoryLocation,
+    hash_deterministic, mv_memory::MvMemory, BuildIdentityHasher, MemoryLocation,
     PevmTxExecutionResult,
 };
 
@@ -122,9 +122,9 @@ impl PevmChain for PevmOptimism {
 
     fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[TxEnv]) -> MvMemory {
         let beneficiary_location_hash =
-            hash_determinisitic(MemoryLocation::Basic(block_env.coinbase));
-        let l1_fee_recipient_location_hash = hash_determinisitic(revm::L1_FEE_RECIPIENT);
-        let base_fee_recipient_location_hash = hash_determinisitic(revm::BASE_FEE_RECIPIENT);
+            hash_deterministic(MemoryLocation::Basic(block_env.coinbase));
+        let l1_fee_recipient_location_hash = hash_deterministic(revm::L1_FEE_RECIPIENT);
+        let base_fee_recipient_location_hash = hash_deterministic(revm::BASE_FEE_RECIPIENT);
 
         // TODO: Estimate more locations based on sender, to, etc.
         let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());
@@ -169,10 +169,10 @@ impl PevmChain for PevmOptimism {
 
     fn get_reward_policy(&self) -> RewardPolicy {
         RewardPolicy::Optimism {
-            l1_fee_recipient_location_hash: hash_determinisitic(MemoryLocation::Basic(
+            l1_fee_recipient_location_hash: hash_deterministic(MemoryLocation::Basic(
                 revm::optimism::L1_FEE_RECIPIENT,
             )),
-            base_fee_vault_location_hash: hash_determinisitic(MemoryLocation::Basic(
+            base_fee_vault_location_hash: hash_deterministic(MemoryLocation::Basic(
                 revm::optimism::BASE_FEE_RECIPIENT,
             )),
         }

--- a/crates/pevm/src/lib.rs
+++ b/crates/pevm/src/lib.rs
@@ -68,7 +68,7 @@ pub type BuildIdentityHasher = BuildHasherDefault<IdentityHasher>;
 // TODO: Ensure it's not easy to hand-craft transactions and storage slots
 // that can cause a lot of collisions that destroys pevm's performance.
 #[inline(always)]
-fn hash_determinisitic<T: Hash>(x: T) -> u64 {
+fn hash_deterministic<T: Hash>(x: T) -> u64 {
     FxBuildHasher.hash_one(x)
 }
 

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -17,7 +17,7 @@ use revm::{
 use crate::{
     chain::PevmChain,
     compat::get_block_env,
-    hash_determinisitic,
+    hash_deterministic,
     mv_memory::MvMemory,
     scheduler::Scheduler,
     storage::StorageWrapper,
@@ -243,7 +243,7 @@ impl Pevm {
         // We fully evaluate (the balance and nonce of) the beneficiary account
         // and raw transfer recipients that may have been atomically updated.
         for address in mv_memory.consume_lazy_addresses() {
-            let location_hash = hash_determinisitic(MemoryLocation::Basic(address));
+            let location_hash = hash_deterministic(MemoryLocation::Basic(address));
             if let Some(write_history) = mv_memory.data.get(&location_hash) {
                 let mut balance = U256::ZERO;
                 let mut nonce = 0;


### PR DESCRIPTION
### Fixed typos in:  
- **`ethereum.rs` and `optimism.rs`**  
  - `"hash_determinisitic"` → `"hash_deterministic"`  
- **`lib.rs`**  
  - `"hash_determinisitic"` → `"hash_deterministic"`  
- **`pevm.rs`**  
  - `"hash_determinisitic"` → `"hash_deterministic"` in multiple locations  
- **`vm.rs`**  
  - `"hash_determinisitic"` → `"hash_deterministic"` in multiple locations  
