### PR TITLE
Fix typos in code comments

### DIFF
--- a/bins/fetch/src/main.rs
+++ b/bins/fetch/src/main.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
     // Define provider.
     let provider = ProviderBuilder::new().on_http(rpc_url);
 
-    // Retrive block from provider.
+    // Retrieve block from provider.
     let block = provider
         .get_block(block_id, BlockTransactionsKind::Full)
         .await

--- a/crates/pevm/tests/ethereum/main.rs
+++ b/crates/pevm/tests/ethereum/main.rs
@@ -191,7 +191,7 @@ fn run_test_unit(path: &Path, unit: TestUnit) {
                         _ => panic!("Mismatched error!\nPath: {path:?}\nExpected: {exception:?}\nGot: {error:?}")
                     });
                 }
-                // Tests that exepect execution to succeed -> match post state root
+                // Tests that expect execution to succeed -> match post state root
                 (None, Ok(exec_results)) => {
                     assert!(exec_results.len() == 1);
                     let PevmTxExecutionResult {receipt, state} = exec_results[0].clone();


### PR DESCRIPTION

This PR fixes two typos in code comments:
- Corrects 'Retrive' to 'Retrieve' in bins/fetch/src/main.rs
- Corrects 'exepect' to 'expect' in crates/pevm/tests/ethereum/main.rs