### PR TITLE
test: add coverage for get_block_env blob gas

### DIFF
--- a/crates/pevm/src/compat.rs
+++ b/crates/pevm/src/compat.rs
@@ -37,3 +37,65 @@ pub(crate) fn get_block_env(header: &Header, spec_id: impl Into<SpecId>) -> Bloc
         }),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::{Address, B256};
+
+    fn test_header() -> Header {
+        let mut header: Header = Header::default();
+        header.number = 42;
+        header.beneficiary = Address::from([0x11; 20]);
+        header.timestamp = 1_717_171_717;
+        header.gas_limit = 30_000_000;
+        header.base_fee_per_gas = Some(123);
+        header.difficulty = U256::from(456);
+        header.mix_hash = B256::from([0x22; 32]);
+        header
+    }
+
+    #[test]
+    fn get_block_env_copies_basic_fields_and_keeps_blob_none() {
+        let header = test_header();
+
+        assert_eq!(
+            get_block_env(&header, SpecId::CANCUN),
+            BlockEnv {
+                number: U256::from(header.number),
+                beneficiary: header.beneficiary,
+                timestamp: U256::from(header.timestamp),
+                gas_limit: header.gas_limit,
+                basefee: header.base_fee_per_gas.unwrap(),
+                difficulty: header.difficulty,
+                prevrandao: Some(header.mix_hash),
+                blob_excess_gas_and_price: None,
+            }
+        );
+    }
+
+    #[test]
+    fn get_block_env_uses_prague_blob_fraction_when_enabled() {
+        let mut header = test_header();
+        header.excess_blob_gas = Some(10_000_000);
+
+        let cancun = BlobExcessGasAndPrice::new(
+            header.excess_blob_gas.unwrap(),
+            BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
+        );
+        let prague = BlobExcessGasAndPrice::new(
+            header.excess_blob_gas.unwrap(),
+            BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
+        );
+
+        assert_ne!(cancun, prague);
+        assert_eq!(
+            get_block_env(&header, SpecId::CANCUN).blob_excess_gas_and_price,
+            Some(cancun),
+        );
+        assert_eq!(
+            get_block_env(&header, SpecId::PRAGUE).blob_excess_gas_and_price,
+            Some(prague),
+        );
+    }
+}

--- a/crates/pevm/src/compat.rs
+++ b/crates/pevm/src/compat.rs
@@ -66,7 +66,7 @@ mod tests {
                 beneficiary: header.beneficiary,
                 timestamp: U256::from(header.timestamp),
                 gas_limit: header.gas_limit,
-                basefee: header.base_fee_per_gas.unwrap(),
+                basefee: header.base_fee_per_gas.unwrap_or_default(),
                 difficulty: header.difficulty,
                 prevrandao: Some(header.mix_hash),
                 blob_excess_gas_and_price: None,
@@ -78,15 +78,12 @@ mod tests {
     fn get_block_env_uses_prague_blob_fraction_when_enabled() {
         let mut header = test_header();
         header.excess_blob_gas = Some(10_000_000);
+        let excess_blob_gas = header.excess_blob_gas.unwrap();
 
-        let cancun = BlobExcessGasAndPrice::new(
-            header.excess_blob_gas.unwrap(),
-            BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN,
-        );
-        let prague = BlobExcessGasAndPrice::new(
-            header.excess_blob_gas.unwrap(),
-            BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE,
-        );
+        let cancun =
+            BlobExcessGasAndPrice::new(excess_blob_gas, BLOB_BASE_FEE_UPDATE_FRACTION_CANCUN);
+        let prague =
+            BlobExcessGasAndPrice::new(excess_blob_gas, BLOB_BASE_FEE_UPDATE_FRACTION_PRAGUE);
 
         assert_ne!(cancun, prague);
         assert_eq!(


### PR DESCRIPTION
Add direct unit tests for `compat::get_block_env`, especially the `blob_excess_gas_and_price` branch mentioned in the TODO.

The new tests verify:
- basic field mapping
- `None` behavior when `excess_blob_gas` is missing
- correct Cancun vs Prague blob fee fraction selection

This is a narrow test-only change with no behavior changes.