### PR TITLE
Replace Mutex with UnsafeCell for execution_results

### DIFF
--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -1,7 +1,8 @@
 use std::{
+    cell::UnsafeCell,
     fmt::Debug,
     num::NonZeroUsize,
-    sync::{Mutex, OnceLock, mpsc},
+    sync::{OnceLock, mpsc},
     thread,
 };
 
@@ -104,10 +105,14 @@ impl<T> AsyncDropper<T> {
 #[derive(Debug, Default)]
 /// The main pevm struct that executes blocks.
 pub struct Pevm {
-    execution_results: Vec<Mutex<Option<PevmTxExecutionResult>>>,
+    // The scheduler guarantees each tx index is written by exactly one thread at a time,
+    // so distinct-index concurrent access is race-free despite UnsafeCell not being Sync.
+    execution_results: Vec<UnsafeCell<Option<PevmTxExecutionResult>>>,
     abort_reason: OnceLock<AbortReason>,
     dropper: AsyncDropper<(MvMemory, Scheduler)>,
 }
+
+unsafe impl Sync for Pevm {}
 
 impl Pevm {
     /// Execute an Alloy block, which is becoming the "standard" format in Rust.
@@ -189,7 +194,7 @@ impl Pevm {
         if additional > 0 {
             self.execution_results.reserve(additional);
             for _ in 0..additional {
-                self.execution_results.push(Mutex::new(None));
+                self.execution_results.push(UnsafeCell::new(None));
             }
         }
 
@@ -243,11 +248,15 @@ impl Pevm {
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
         for i in 0..block_size {
-            let mut execution_result = index_mutex!(self.execution_results, i).take().unwrap();
+            let taken = unsafe { (*self.execution_results.get_unchecked(i).get()).take() };
+            let Some(mut result) = taken else {
+                return Err(PevmError::UnreachableError);
+            };
+
             cumulative_gas_used =
-                cumulative_gas_used.saturating_add(execution_result.receipt.cumulative_gas_used);
-            execution_result.receipt.cumulative_gas_used = cumulative_gas_used;
-            fully_evaluated_results.push(execution_result);
+                cumulative_gas_used.saturating_add(result.receipt.cumulative_gas_used);
+            result.receipt.cumulative_gas_used = cumulative_gas_used;
+            fully_evaluated_results.push(result);
         }
 
         // We fully evaluate (the balance and nonce of) the beneficiary account
@@ -412,8 +421,14 @@ impl Pevm {
                     execution_result,
                     flags,
                 }) => {
-                    *index_mutex!(self.execution_results, tx_version.tx_idx) =
-                        Some(execution_result);
+                    // SAFETY: scheduler ensures tx_idx < block_size and no two threads write
+                    // to the same index concurrently.
+                    unsafe {
+                        *self
+                            .execution_results
+                            .get_unchecked(tx_version.tx_idx)
+                            .get() = Some(execution_result);
+                    }
                     scheduler.finish_execution(tx_version, flags)
                 }
             };

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -112,6 +112,8 @@ pub struct Pevm {
     dropper: AsyncDropper<(MvMemory, Scheduler)>,
 }
 
+// SAFETY: The scheduler guarantees that each transaction index is written by exactly one thread at a time,
+// and results are only read after all threads have joined. Other fields are either Sync or safe to share.
 unsafe impl Sync for Pevm {}
 
 impl Pevm {
@@ -248,6 +250,7 @@ impl Pevm {
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
         for i in 0..block_size {
+            // SAFETY: All worker threads have joined, and the index is guaranteed to be in bounds.
             let taken = unsafe { (*self.execution_results.get_unchecked(i).get()).take() };
             let Some(mut result) = taken else {
                 return Err(PevmError::UnreachableError);

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::UnsafeCell,
-    fmt::Debug,
+    fmt::{self, Debug},
     num::NonZeroUsize,
     sync::{OnceLock, mpsc},
     thread,
@@ -24,7 +24,7 @@ use crate::{
     mv_memory::MvMemory,
     scheduler::Scheduler,
     storage::StorageWrapper,
-    vm::{ExecutionError, PevmTxExecutionResult, Vm, VmExecutionError, VmExecutionResult},
+    vm::{ExecutionError, PevmTxExecutionResult, Vm, VmExecutionError},
 };
 
 /// Errors when executing a block with pevm.
@@ -101,20 +101,34 @@ impl<T> AsyncDropper<T> {
     }
 }
 
+// One slot in the per-block result array. The scheduler guarantees that only the thread
+// executing a given tx index accesses its slot, so interior mutability is safe.
+struct PendingExecutionResult(UnsafeCell<Option<PevmTxExecutionResult>>);
+
+// SAFETY: The scheduler ensures at most one thread accesses a given slot at a time,
+// and the collection phase runs only after all worker threads have joined.
+unsafe impl Sync for PendingExecutionResult {}
+
+impl Default for PendingExecutionResult {
+    fn default() -> Self {
+        Self(UnsafeCell::new(None))
+    }
+}
+
+impl fmt::Debug for PendingExecutionResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("PendingExecutionResult { .. }")
+    }
+}
+
 // TODO: Port more recyclable resources into here.
 #[derive(Debug, Default)]
 /// The main pevm struct that executes blocks.
 pub struct Pevm {
-    // The scheduler guarantees each tx index is written by exactly one thread at a time,
-    // so distinct-index concurrent access is race-free despite UnsafeCell not being Sync.
-    execution_results: Vec<UnsafeCell<Option<PevmTxExecutionResult>>>,
+    execution_results: Vec<PendingExecutionResult>,
     abort_reason: OnceLock<AbortReason>,
     dropper: AsyncDropper<(MvMemory, Scheduler)>,
 }
-
-// SAFETY: The scheduler guarantees that each transaction index is written by exactly one thread at a time,
-// and results are only read after all threads have joined. Other fields are either Sync or safe to share.
-unsafe impl Sync for Pevm {}
 
 impl Pevm {
     /// Execute an Alloy block, which is becoming the "standard" format in Rust.
@@ -196,7 +210,7 @@ impl Pevm {
         if additional > 0 {
             self.execution_results.reserve(additional);
             for _ in 0..additional {
-                self.execution_results.push(UnsafeCell::new(None));
+                self.execution_results.push(PendingExecutionResult::default());
             }
         }
 
@@ -249,12 +263,10 @@ impl Pevm {
 
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
-        for i in 0..block_size {
-            // SAFETY: All worker threads have joined, and the index is guaranteed to be in bounds.
-            let taken = unsafe { (*self.execution_results.get_unchecked(i).get()).take() };
-            let Some(mut result) = taken else {
-                return Err(PevmError::UnreachableError);
-            };
+        for slot in &mut self.execution_results[..block_size] {
+            // SAFETY: the scheduler guarantees every tx in 0..block_size completes before
+            // we reach this point, so every slot is guaranteed to hold Some(_).
+            let mut result = unsafe { (*slot.0.get()).take().unwrap_unchecked() };
 
             cumulative_gas_used =
                 cumulative_gas_used.saturating_add(result.receipt.cumulative_gas_used);
@@ -390,8 +402,17 @@ impl Pevm {
         scheduler: &Scheduler,
         tx_version: TxVersion,
     ) -> Option<Task> {
+        // SAFETY: scheduler guarantees exclusive access to this index while executing.
+        let out = unsafe {
+            &mut *self
+                .execution_results
+                .get_unchecked(tx_version.tx_idx)
+                .0
+                .get()
+        };
         loop {
-            return match vm.execute(&tx_version) {
+            return match vm.execute(&tx_version, out) {
+                Ok(flags) => scheduler.finish_execution(tx_version, flags),
                 Err(VmExecutionError::Retry) => {
                     if self.abort_reason.get().is_none() {
                         continue;
@@ -419,20 +440,6 @@ impl Pevm {
                     self.abort_reason
                         .get_or_init(|| AbortReason::ExecutionError(err));
                     None
-                }
-                Ok(VmExecutionResult {
-                    execution_result,
-                    flags,
-                }) => {
-                    // SAFETY: scheduler ensures tx_idx < block_size and no two threads write
-                    // to the same index concurrently.
-                    unsafe {
-                        *self
-                            .execution_results
-                            .get_unchecked(tx_version.tx_idx)
-                            .get() = Some(execution_result);
-                    }
-                    scheduler.finish_execution(tx_version, flags)
                 }
             };
         }

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::UnsafeCell,
-    fmt::{self, Debug},
+    fmt::Debug,
     num::NonZeroUsize,
     sync::{OnceLock, mpsc},
     thread,
@@ -101,23 +101,52 @@ impl<T> AsyncDropper<T> {
     }
 }
 
-// One slot in the per-block result array. The scheduler guarantees that only the thread
-// executing a given tx index accesses its slot, so interior mutability is safe.
-struct PendingExecutionResult(UnsafeCell<Option<PevmTxExecutionResult>>);
+// Reusable per-block execution result buffer. Each slot is an UnsafeCell so workers
+// can write into it while sharing a &-reference to the container via thread::scope,
+// without the overhead of Mutex per slot.
+//
+// All three unsafe operations are centralised here because they share the same
+// invariant: the scheduler assigns exclusive Executing status to exactly one thread
+// per slot at a time, and the drain phase runs only after all worker threads have
+// joined (providing the necessary happens-before barrier).
+#[derive(Debug, Default)]
+struct PendingExecutionResults(Vec<UnsafeCell<Option<PevmTxExecutionResult>>>);
 
-// SAFETY: The scheduler ensures at most one thread accesses a given slot at a time,
-// and the collection phase runs only after all worker threads have joined.
-unsafe impl Sync for PendingExecutionResult {}
+// SAFETY: See the invariant above - the scheduler prevents concurrent slot access.
+unsafe impl Sync for PendingExecutionResults {}
 
-impl Default for PendingExecutionResult {
-    fn default() -> Self {
-        Self(UnsafeCell::new(None))
+impl PendingExecutionResults {
+    // Grow the buffer so that indices 0..block_size are valid.
+    fn grow_to(&mut self, block_size: usize) {
+        let additional = block_size.saturating_sub(self.0.len());
+        if additional > 0 {
+            self.0.reserve(additional);
+            for _ in 0..additional {
+                self.0.push(UnsafeCell::new(None));
+            }
+        }
     }
-}
 
-impl fmt::Debug for PendingExecutionResult {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("PendingExecutionResult { .. }")
+    // Borrow slot `tx_idx` mutably through the shared container.
+    //
+    // SAFETY: This is sound because the scheduler grants the Executing claim for a
+    // given tx_idx to exactly one thread at a time, so callers from within this crate
+    // never invoke this with the same index concurrently. The type is crate-private
+    // and has a single caller (`try_execute`), so this invariant is enforced by
+    // construction.
+    #[allow(clippy::mut_from_ref)]
+    fn slot_mut(&self, tx_idx: TxIdx) -> &mut Option<PevmTxExecutionResult> {
+        unsafe { &mut *self.0[tx_idx].get() }
+    }
+
+    // Drain the first `block_size` slots after all workers have joined, resetting each
+    // to None so they are ready for the next block.
+    // SAFETY: must only be called after all worker threads have joined; the scheduler
+    // guarantees every slot in 0..block_size was populated by a completed execution.
+    fn drain(&self, block_size: usize) -> impl Iterator<Item = PevmTxExecutionResult> + '_ {
+        self.0[..block_size]
+            .iter()
+            .map(|cell| unsafe { (*cell.get()).take().unwrap_unchecked() })
     }
 }
 
@@ -125,7 +154,7 @@ impl fmt::Debug for PendingExecutionResult {
 #[derive(Debug, Default)]
 /// The main pevm struct that executes blocks.
 pub struct Pevm {
-    execution_results: Vec<PendingExecutionResult>,
+    execution_results: PendingExecutionResults,
     abort_reason: OnceLock<AbortReason>,
     dropper: AsyncDropper<(MvMemory, Scheduler)>,
 }
@@ -206,14 +235,7 @@ impl Pevm {
 
         let mv_memory = chain.build_mv_memory(&block_env, &txs);
 
-        let additional = block_size.saturating_sub(self.execution_results.len());
-        if additional > 0 {
-            self.execution_results.reserve(additional);
-            for _ in 0..additional {
-                self.execution_results
-                    .push(PendingExecutionResult::default());
-            }
-        }
+        self.execution_results.grow_to(block_size);
 
         // TODO: Better thread handling
         thread::scope(|scope| {
@@ -264,11 +286,7 @@ impl Pevm {
 
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
-        for slot in &mut self.execution_results[..block_size] {
-            // SAFETY: the scheduler guarantees every tx in 0..block_size completes before
-            // we reach this point, so every slot is guaranteed to hold Some(_).
-            let mut result = unsafe { (*slot.0.get()).take().unwrap_unchecked() };
-
+        for mut result in self.execution_results.drain(block_size) {
             cumulative_gas_used =
                 cumulative_gas_used.saturating_add(result.receipt.cumulative_gas_used);
             result.receipt.cumulative_gas_used = cumulative_gas_used;
@@ -403,14 +421,7 @@ impl Pevm {
         scheduler: &Scheduler,
         tx_version: TxVersion,
     ) -> Option<Task> {
-        // SAFETY: scheduler guarantees exclusive access to this index while executing.
-        let out = unsafe {
-            &mut *self
-                .execution_results
-                .get_unchecked(tx_version.tx_idx)
-                .0
-                .get()
-        };
+        let out = self.execution_results.slot_mut(tx_version.tx_idx);
         loop {
             return match vm.execute(&tx_version, out) {
                 Ok(flags) => scheduler.finish_execution(tx_version, flags),

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -210,7 +210,8 @@ impl Pevm {
         if additional > 0 {
             self.execution_results.reserve(additional);
             for _ in 0..additional {
-                self.execution_results.push(PendingExecutionResult::default());
+                self.execution_results
+                    .push(PendingExecutionResult::default());
             }
         }
 

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -116,31 +116,28 @@ impl<T> AsyncDropper<T> {
 // per slot at a time, and result collection runs only after all worker threads have
 // joined. Other worker tasks like validation don't touch these results at all.
 #[derive(Debug, Default)]
-struct PendingExecutionResults(Vec<UnsafeCell<Option<PevmTxExecutionResult>>>);
+struct ExecutionResults(Vec<UnsafeCell<Option<PevmTxExecutionResult>>>);
 
-// SAFETY: See the invariant above - the scheduler prevents concurrent slot access.
-unsafe impl Sync for PendingExecutionResults {}
+unsafe impl Sync for ExecutionResults {}
 
-impl PendingExecutionResults {
+impl ExecutionResults {
     fn grow_to(&mut self, block_size: usize) {
         if block_size > self.0.len() {
             self.0.resize_with(block_size, || UnsafeCell::new(None));
         }
     }
 
-    // Borrow slot `tx_idx` mutably through the shared container.
     #[allow(clippy::mut_from_ref)]
     fn slot_mut(&self, tx_idx: TxIdx) -> &mut Option<PevmTxExecutionResult> {
         unsafe { &mut *self.0.get_unchecked(tx_idx).get() }
     }
 
-    // Take the first `block_size` results after all workers have joined, resetting each
-    // slot to None so they are ready for the next block.
-    fn take(&self, block_size: usize) -> Vec<PevmTxExecutionResult> {
-        unsafe { self.0.get_unchecked(..block_size) }
-            .iter()
-            .map(|cell| unsafe { (*cell.get()).take().unwrap_unchecked() })
-            .collect()
+    fn take_slot(&self, tx_idx: TxIdx) -> PevmTxExecutionResult {
+        unsafe {
+            (*self.0.get_unchecked(tx_idx).get())
+                .take()
+                .unwrap_unchecked()
+        }
     }
 }
 
@@ -148,7 +145,7 @@ impl PendingExecutionResults {
 #[derive(Debug, Default)]
 /// The main pevm struct that executes blocks.
 pub struct Pevm {
-    execution_results: PendingExecutionResults,
+    execution_results: ExecutionResults,
     abort_reason: OnceLock<AbortReason>,
     dropper: AsyncDropper<(MvMemory, Scheduler)>,
 }
@@ -280,11 +277,12 @@ impl Pevm {
 
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
-        for mut result in self.execution_results.take(block_size) {
+        for tx_idx in 0..block_size {
+            let mut execution_result = self.execution_results.take_slot(tx_idx);
             cumulative_gas_used =
-                cumulative_gas_used.saturating_add(result.receipt.cumulative_gas_used);
-            result.receipt.cumulative_gas_used = cumulative_gas_used;
-            fully_evaluated_results.push(result);
+                cumulative_gas_used.saturating_add(execution_result.receipt.cumulative_gas_used);
+            execution_result.receipt.cumulative_gas_used = cumulative_gas_used;
+            fully_evaluated_results.push(execution_result);
         }
 
         // We fully evaluate (the balance and nonce of) the beneficiary account
@@ -476,6 +474,7 @@ pub fn execute_revm_sequential<S: Storage + Debug, C: PevmChain>(
     txs: Vec<C::EvmTx>,
 ) -> PevmResult<C> {
     let db = CacheDB::new(StorageWrapper(storage));
+    let is_eip_161_enabled = chain.is_eip_161_enabled(spec_id);
     let mut evm = chain.build_evm(spec_id, block_env, db);
 
     let mut results: Vec<PevmTxExecutionResult> = Vec::with_capacity(txs.len());
@@ -490,7 +489,7 @@ pub fn execute_revm_sequential<S: Storage + Debug, C: PevmChain>(
 
         let mut execution_result = PevmTxExecutionResult {
             receipt: receipt_from_revm(result),
-            state: state_transitions_from_revm(chain.is_eip_161_enabled(spec_id), state).collect(),
+            state: state_transitions_from_revm(is_eip_161_enabled, state),
         };
 
         cumulative_gas_used =

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -489,7 +489,7 @@ pub fn execute_revm_sequential<S: Storage + Debug, C: PevmChain>(
 
         let mut execution_result = PevmTxExecutionResult {
             receipt: receipt_from_revm(result),
-            state: state_transitions_from_revm(is_eip_161_enabled, state),
+            state: state_transitions_from_revm(is_eip_161_enabled, state).collect(),
         };
 
         cumulative_gas_used =

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -11,7 +11,10 @@ use alloy_rpc_types_eth::{Block, BlockTransactions};
 use hashbrown::HashMap;
 use revm::{
     DatabaseCommit, ExecuteEvm,
-    context::{BlockEnv, ContextTr, Transaction, result::InvalidTransaction},
+    context::{
+        BlockEnv, ContextTr, Transaction,
+        result::{InvalidTransaction, ResultAndState},
+    },
     database::CacheDB,
     handler::EvmTr,
 };
@@ -24,7 +27,10 @@ use crate::{
     mv_memory::MvMemory,
     scheduler::Scheduler,
     storage::StorageWrapper,
-    vm::{ExecutionError, PevmTxExecutionResult, Vm, VmExecutionError},
+    vm::{
+        ExecutionError, PevmTxExecutionResult, Vm, VmExecutionError, receipt_from_revm,
+        state_transitions_from_revm,
+    },
 };
 
 /// Errors when executing a block with pevm.
@@ -101,14 +107,14 @@ impl<T> AsyncDropper<T> {
     }
 }
 
-// Reusable per-block execution result buffer. Each slot is an UnsafeCell so workers
-// can write into it while sharing a &-reference to the container via thread::scope,
-// without the overhead of Mutex per slot.
+// Reusable per-block execution result buffer. Each slot is an `UnsafeCell` so workers
+// can write into it while sharing a thread-safe reference to the buffer at runtime
+// without synchronisation overheads (like putting each slot behind a mutex).
 //
-// All three unsafe operations are centralised here because they share the same
-// invariant: the scheduler assigns exclusive Executing status to exactly one thread
-// per slot at a time, and the drain phase runs only after all worker threads have
-// joined (providing the necessary happens-before barrier).
+// All unsafe operations are centralised here as they share the same invariant:
+// The scheduler assigns exclusive `Executing` status to exactly one worker thread
+// per slot at a time, and result collection runs only after all worker threads have
+// joined. Other worker tasks like validation don't touch these results at all.
 #[derive(Debug, Default)]
 struct PendingExecutionResults(Vec<UnsafeCell<Option<PevmTxExecutionResult>>>);
 
@@ -116,37 +122,25 @@ struct PendingExecutionResults(Vec<UnsafeCell<Option<PevmTxExecutionResult>>>);
 unsafe impl Sync for PendingExecutionResults {}
 
 impl PendingExecutionResults {
-    // Grow the buffer so that indices 0..block_size are valid.
     fn grow_to(&mut self, block_size: usize) {
-        let additional = block_size.saturating_sub(self.0.len());
-        if additional > 0 {
-            self.0.reserve(additional);
-            for _ in 0..additional {
-                self.0.push(UnsafeCell::new(None));
-            }
+        if block_size > self.0.len() {
+            self.0.resize_with(block_size, || UnsafeCell::new(None));
         }
     }
 
     // Borrow slot `tx_idx` mutably through the shared container.
-    //
-    // SAFETY: This is sound because the scheduler grants the Executing claim for a
-    // given tx_idx to exactly one thread at a time, so callers from within this crate
-    // never invoke this with the same index concurrently. The type is crate-private
-    // and has a single caller (`try_execute`), so this invariant is enforced by
-    // construction.
     #[allow(clippy::mut_from_ref)]
     fn slot_mut(&self, tx_idx: TxIdx) -> &mut Option<PevmTxExecutionResult> {
-        unsafe { &mut *self.0[tx_idx].get() }
+        unsafe { &mut *self.0.get_unchecked(tx_idx).get() }
     }
 
-    // Drain the first `block_size` slots after all workers have joined, resetting each
-    // to None so they are ready for the next block.
-    // SAFETY: must only be called after all worker threads have joined; the scheduler
-    // guarantees every slot in 0..block_size was populated by a completed execution.
-    fn drain(&self, block_size: usize) -> impl Iterator<Item = PevmTxExecutionResult> + '_ {
-        self.0[..block_size]
+    // Take the first `block_size` results after all workers have joined, resetting each
+    // slot to None so they are ready for the next block.
+    fn take(&self, block_size: usize) -> Vec<PevmTxExecutionResult> {
+        unsafe { self.0.get_unchecked(..block_size) }
             .iter()
             .map(|cell| unsafe { (*cell.get()).take().unwrap_unchecked() })
+            .collect()
     }
 }
 
@@ -286,7 +280,7 @@ impl Pevm {
 
         let mut fully_evaluated_results = Vec::with_capacity(block_size);
         let mut cumulative_gas_used: u64 = 0;
-        for mut result in self.execution_results.drain(block_size) {
+        for mut result in self.execution_results.take(block_size) {
             cumulative_gas_used =
                 cumulative_gas_used.saturating_add(result.receipt.cumulative_gas_used);
             result.receipt.cumulative_gas_used = cumulative_gas_used;
@@ -421,9 +415,9 @@ impl Pevm {
         scheduler: &Scheduler,
         tx_version: TxVersion,
     ) -> Option<Task> {
-        let out = self.execution_results.slot_mut(tx_version.tx_idx);
+        let result_slot = self.execution_results.slot_mut(tx_version.tx_idx);
         loop {
-            return match vm.execute(&tx_version, out) {
+            return match vm.execute(&tx_version, result_slot) {
                 Ok(flags) => scheduler.finish_execution(tx_version, flags),
                 Err(VmExecutionError::Retry) => {
                     if self.abort_reason.get().is_none() {
@@ -488,14 +482,16 @@ pub fn execute_revm_sequential<S: Storage + Debug, C: PevmChain>(
     let mut cumulative_gas_used: u64 = 0;
     for tx in txs {
         // TODO: More concrete error type
-        let result_and_state = evm
+        let ResultAndState { result, state } = evm
             .transact(tx)
             .map_err(|err| ExecutionError::Custom(err.to_string()))?;
 
-        evm.ctx().db_mut().commit(result_and_state.state.clone());
+        evm.ctx().db_mut().commit(state.clone());
 
-        let mut execution_result =
-            PevmTxExecutionResult::from_revm(chain, spec_id, result_and_state);
+        let mut execution_result = PevmTxExecutionResult {
+            receipt: receipt_from_revm(result),
+            state: state_transitions_from_revm(chain.is_eip_161_enabled(spec_id), state).collect(),
+        };
 
         cumulative_gas_used =
             cumulative_gas_used.saturating_add(execution_result.receipt.cumulative_gas_used);

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -5,11 +5,11 @@ use revm::{
     Database,
     context::{
         BlockEnv, ContextSetters, ContextTr, DBErrorMarker, JournalTr, TxEnv,
-        result::{EVMError, InvalidTransaction, ResultAndState},
+        result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
     },
     handler::{EvmTr, FrameResult, Handler},
     primitives::KECCAK_EMPTY,
-    state::{AccountInfo, Bytecode},
+    state::{Account, AccountInfo, Bytecode},
 };
 use smallvec::SmallVec;
 
@@ -38,6 +38,33 @@ pub struct PevmTxExecutionResult {
     pub state: EvmStateTransitions,
 }
 
+fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
+    Receipt {
+        status: result.is_success().into(),
+        cumulative_gas_used: result.tx_gas_used(),
+        logs: result.into_logs(),
+    }
+}
+
+fn state_transitions_from_revm<'a, C: PevmChain>(
+    chain: &'a C,
+    spec_id: C::EvmSpecId,
+    state: impl IntoIterator<Item = (Address, Account)> + 'a,
+) -> impl Iterator<Item = (Address, Option<EvmAccount>)> + 'a {
+    state
+        .into_iter()
+        .filter(|(_, account)| account.is_touched())
+        .map(move |(address, account)| {
+            if account.is_selfdestructed()
+                || account.is_empty() && chain.is_eip_161_enabled(spec_id)
+            {
+                (address, None)
+            } else {
+                (address, Some(EvmAccount::from(account)))
+            }
+        })
+}
+
 impl PevmTxExecutionResult {
     /// Construct a Pevm execution result from a raw Revm result.
     /// Note that [`cumulative_gas_used`] is preset to the gas used in this transaction.
@@ -48,53 +75,22 @@ impl PevmTxExecutionResult {
         ResultAndState { result, state }: ResultAndState<C::EvmHaltReason>,
     ) -> Self {
         Self {
-            receipt: Receipt {
-                status: result.is_success().into(),
-                cumulative_gas_used: result.tx_gas_used(),
-                logs: result.into_logs(),
-            },
-            state: state
-                .into_iter()
-                .filter(|(_, account)| account.is_touched())
-                .map(|(address, account)| {
-                    if account.is_selfdestructed()
-                        || account.is_empty() && chain.is_eip_161_enabled(spec_id)
-                    {
-                        (address, None)
-                    } else {
-                        (address, Some(EvmAccount::from(account)))
-                    }
-                })
-                .collect(),
+            receipt: receipt_from_revm(result),
+            state: state_transitions_from_revm(chain, spec_id, state).collect(),
         }
     }
 
-    // Reuse existing heap allocations (logs Vec, state HashMap) from a prior
-    // incarnation and assign new values from a new Revm execution result.
+    // Reuse the existing state HashMap allocation from a prior incarnation.
     fn assign_from_revm<C: PevmChain>(
         &mut self,
         chain: &C,
         spec_id: C::EvmSpecId,
         ResultAndState { result, state }: ResultAndState<C::EvmHaltReason>,
     ) {
-        self.receipt.status = result.is_success().into();
-        self.receipt.cumulative_gas_used = result.tx_gas_used();
-        self.receipt.logs = result.into_logs();
+        self.receipt = receipt_from_revm(result);
         self.state.clear();
-        self.state.extend(
-            state
-                .into_iter()
-                .filter(|(_, account)| account.is_touched())
-                .map(|(address, account)| {
-                    if account.is_selfdestructed()
-                        || account.is_empty() && chain.is_eip_161_enabled(spec_id)
-                    {
-                        (address, None)
-                    } else {
-                        (address, Some(EvmAccount::from(account)))
-                    }
-                }),
-        );
+        self.state
+            .extend(state_transitions_from_revm(chain, spec_id, state));
     }
 }
 

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -53,7 +53,7 @@ pub(crate) fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
 pub(crate) fn state_transitions_from_revm(
     is_eip_161_enabled: bool,
     state: EvmState,
-) -> EvmStateTransitions {
+) -> impl Iterator<Item = (Address, Option<EvmAccount>)> {
     state
         .into_iter()
         .filter(|(_, account)| account.is_touched())
@@ -64,7 +64,6 @@ pub(crate) fn state_transitions_from_revm(
                 (address, Some(EvmAccount::from(account)))
             }
         })
-        .collect()
 }
 
 pub(crate) enum VmExecutionError {
@@ -730,7 +729,10 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     slot.state.clear();
                     slot.state.extend(state);
                 } else {
-                    *result_slot = Some(PevmTxExecutionResult { receipt, state });
+                    *result_slot = Some(PevmTxExecutionResult {
+                        receipt,
+                        state: state.collect(),
+                    });
                 }
                 Ok(flags)
             }

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -68,6 +68,35 @@ impl PevmTxExecutionResult {
                 .collect(),
         }
     }
+
+    // Reuse existing heap allocations (logs Vec, state HashMap) from a prior
+    // incarnation and assign new values from a new Revm execution result.
+    fn assign_from_revm<C: PevmChain>(
+        &mut self,
+        chain: &C,
+        spec_id: C::EvmSpecId,
+        ResultAndState { result, state }: ResultAndState<C::EvmHaltReason>,
+    ) {
+        self.receipt.status = result.is_success().into();
+        self.receipt.cumulative_gas_used = result.tx_gas_used();
+        self.receipt.logs.clear();
+        self.receipt.logs.extend(result.into_logs());
+        self.state.clear();
+        self.state.extend(
+            state
+                .into_iter()
+                .filter(|(_, account)| account.is_touched())
+                .map(|(address, account)| {
+                    if account.is_selfdestructed()
+                        || account.is_empty() && chain.is_eip_161_enabled(spec_id)
+                    {
+                        (address, None)
+                    } else {
+                        (address, Some(EvmAccount::from(account)))
+                    }
+                }),
+        );
+    }
 }
 
 pub(crate) enum VmExecutionError {
@@ -117,11 +146,6 @@ impl From<ReadError> for VmExecutionError {
             _ => Self::ExecutionError(EVMError::Database(err)),
         }
     }
-}
-
-pub(crate) struct VmExecutionResult {
-    pub(crate) execution_result: PevmTxExecutionResult,
-    pub(crate) flags: FinishExecFlags,
 }
 
 // A database interface that intercepts reads while executing a specific
@@ -548,7 +572,8 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
     pub(crate) fn execute(
         &mut self,
         tx_version: &TxVersion,
-    ) -> Result<VmExecutionResult, VmExecutionError> {
+        out: &mut Option<PevmTxExecutionResult>,
+    ) -> Result<FinishExecFlags, VmExecutionError> {
         // SAFETY: A correct scheduler would guarantee this index to be inbound.
         let full_tx = unsafe { self.txs.get_unchecked(tx_version.tx_idx) };
         let tx = self.chain.tx_env(full_tx);
@@ -734,14 +759,19 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     flags |= FinishExecFlags::WroteNewLocation;
                 }
 
-                Ok(VmExecutionResult {
-                    execution_result: PevmTxExecutionResult::from_revm(
-                        self.chain,
-                        self.spec_id,
-                        result_and_state,
-                    ),
-                    flags,
-                })
+                match out {
+                    Some(result) => {
+                        result.assign_from_revm(self.chain, self.spec_id, result_and_state)
+                    }
+                    None => {
+                        *out = Some(PevmTxExecutionResult::from_revm(
+                            self.chain,
+                            self.spec_id,
+                            result_and_state,
+                        ))
+                    }
+                }
+                Ok(flags)
             }
             Err(EVMError::Database(read_error)) => Err(VmExecutionError::from(read_error)),
             Err(err) => {

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -79,8 +79,7 @@ impl PevmTxExecutionResult {
     ) {
         self.receipt.status = result.is_success().into();
         self.receipt.cumulative_gas_used = result.tx_gas_used();
-        self.receipt.logs.clear();
-        self.receipt.logs.extend(result.into_logs());
+        self.receipt.logs = result.into_logs();
         self.state.clear();
         self.state.extend(
             state

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -9,7 +9,7 @@ use revm::{
     },
     handler::{EvmTr, FrameResult, Handler},
     primitives::KECCAK_EMPTY,
-    state::{Account, AccountInfo, Bytecode},
+    state::{AccountInfo, Bytecode, EvmState},
 };
 use smallvec::SmallVec;
 
@@ -38,7 +38,7 @@ pub struct PevmTxExecutionResult {
     pub state: EvmStateTransitions,
 }
 
-fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
+pub(crate) fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
     Receipt {
         status: result.is_success().into(),
         cumulative_gas_used: result.tx_gas_used(),
@@ -46,52 +46,20 @@ fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
     }
 }
 
-fn state_transitions_from_revm<'a, C: PevmChain>(
-    chain: &'a C,
-    spec_id: C::EvmSpecId,
-    state: impl IntoIterator<Item = (Address, Account)> + 'a,
-) -> impl Iterator<Item = (Address, Option<EvmAccount>)> + 'a {
+pub(crate) fn state_transitions_from_revm(
+    is_eip_161_enabled: bool,
+    state: EvmState,
+) -> impl Iterator<Item = (Address, Option<EvmAccount>)> {
     state
         .into_iter()
         .filter(|(_, account)| account.is_touched())
         .map(move |(address, account)| {
-            if account.is_selfdestructed()
-                || account.is_empty() && chain.is_eip_161_enabled(spec_id)
-            {
+            if account.is_selfdestructed() || account.is_empty() && is_eip_161_enabled {
                 (address, None)
             } else {
                 (address, Some(EvmAccount::from(account)))
             }
         })
-}
-
-impl PevmTxExecutionResult {
-    /// Construct a Pevm execution result from a raw Revm result.
-    /// Note that [`cumulative_gas_used`] is preset to the gas used in this transaction.
-    /// It should be post-processed with the remaining transactions in the block.
-    pub fn from_revm<C: PevmChain>(
-        chain: &C,
-        spec_id: C::EvmSpecId,
-        ResultAndState { result, state }: ResultAndState<C::EvmHaltReason>,
-    ) -> Self {
-        Self {
-            receipt: receipt_from_revm(result),
-            state: state_transitions_from_revm(chain, spec_id, state).collect(),
-        }
-    }
-
-    // Reuse the existing state HashMap allocation from a prior incarnation.
-    fn assign_from_revm<C: PevmChain>(
-        &mut self,
-        chain: &C,
-        spec_id: C::EvmSpecId,
-        ResultAndState { result, state }: ResultAndState<C::EvmHaltReason>,
-    ) {
-        self.receipt = receipt_from_revm(result);
-        self.state.clear();
-        self.state
-            .extend(state_transitions_from_revm(chain, spec_id, state));
-    }
 }
 
 pub(crate) enum VmExecutionError {
@@ -499,13 +467,13 @@ impl<S: Storage> Database for VmDb<'_, S> {
 pub(crate) struct Vm<'a, S: Storage, C: PevmChain> {
     // Shared block-level state
     chain: &'a C,
-    spec_id: C::EvmSpecId,
     block_env: &'a BlockEnv,
     txs: &'a [C::EvmTx],
     mv_memory: &'a MvMemory,
     beneficiary_location_hash: MemoryLocationHash,
     // Dedicated EVM for the worker, reset before each transaction exectution.
     evm: C::Evm<VmDb<'a, S>>,
+    is_eip_161_enabled: bool,
 }
 
 impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
@@ -537,7 +505,6 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
         };
         Self {
             chain,
-            spec_id,
             block_env,
             txs,
             mv_memory,
@@ -545,6 +512,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                 block_env.beneficiary,
             )),
             evm: chain.build_evm(spec_id, block_env.clone(), db),
+            is_eip_161_enabled: chain.is_eip_161_enabled(spec_id),
         }
     }
 
@@ -567,7 +535,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
     pub(crate) fn execute(
         &mut self,
         tx_version: &TxVersion,
-        out: &mut Option<PevmTxExecutionResult>,
+        result_slot: &mut Option<PevmTxExecutionResult>,
     ) -> Result<FinishExecFlags, VmExecutionError> {
         // SAFETY: A correct scheduler would guarantee this index to be inbound.
         let full_tx = unsafe { self.txs.get_unchecked(tx_version.tx_idx) };
@@ -658,9 +626,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                             // and return a [None], i.e., [LoadedAsNotExisting]. Without
                             // this check it would write then read a [Some] default
                             // account, which may yield a wrong gas fee, etc.
-                            else if !self.chain.is_eip_161_enabled(self.spec_id)
-                                || !account.is_empty()
-                            {
+                            else if !self.is_eip_161_enabled || !account.is_empty() {
                                 write_set.push((
                                     account_location_hash,
                                     MemoryValue::Basic(AccountBasic {
@@ -702,7 +668,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                 } else {
                     tx.gas_price
                 };
-                if self.chain.is_eip_1559_enabled(self.spec_id) {
+                if self.is_eip_161_enabled {
                     gas_price = gas_price.saturating_sub(self.block_env.basefee as u128);
                 }
                 let rewards = self.chain.get_rewards(
@@ -754,16 +720,20 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     flags |= FinishExecFlags::WroteNewLocation;
                 }
 
-                match out {
-                    Some(result) => {
-                        result.assign_from_revm(self.chain, self.spec_id, result_and_state)
+                let ResultAndState { result, state } = result_and_state;
+                match result_slot {
+                    Some(slot) => {
+                        slot.receipt = receipt_from_revm(result);
+                        slot.state.clear();
+                        slot.state
+                            .extend(state_transitions_from_revm(self.is_eip_161_enabled, state));
                     }
                     None => {
-                        *out = Some(PevmTxExecutionResult::from_revm(
-                            self.chain,
-                            self.spec_id,
-                            result_and_state,
-                        ))
+                        *result_slot = Some(PevmTxExecutionResult {
+                            receipt: receipt_from_revm(result),
+                            state: state_transitions_from_revm(self.is_eip_161_enabled, state)
+                                .collect(),
+                        });
                     }
                 }
                 Ok(flags)

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -5,7 +5,7 @@ use revm::{
     Database,
     context::{
         BlockEnv, ContextSetters, ContextTr, DBErrorMarker, JournalTr, TxEnv,
-        result::{EVMError, ExecutionResult, InvalidTransaction, ResultAndState},
+        result::{EVMError, ExecutionResult, InvalidTransaction},
     },
     handler::{EvmTr, FrameResult, Handler},
     primitives::KECCAK_EMPTY,
@@ -38,6 +38,9 @@ pub struct PevmTxExecutionResult {
     pub state: EvmStateTransitions,
 }
 
+/// Convert Revm's execution result into a standard receipt.
+/// Note that the cumulative gas used in the receipt is preset to the gas used in this transaction.
+/// It should be post-processed with the remaining transactions in the block.
 pub(crate) fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
     Receipt {
         status: result.is_success().into(),
@@ -46,10 +49,11 @@ pub(crate) fn receipt_from_revm<H>(result: ExecutionResult<H>) -> Receipt {
     }
 }
 
+/// Convert Revm's state transitions into PEVM's state transitions.
 pub(crate) fn state_transitions_from_revm(
     is_eip_161_enabled: bool,
     state: EvmState,
-) -> impl Iterator<Item = (Address, Option<EvmAccount>)> {
+) -> EvmStateTransitions {
     state
         .into_iter()
         .filter(|(_, account)| account.is_touched())
@@ -60,6 +64,7 @@ pub(crate) fn state_transitions_from_revm(
                 (address, Some(EvmAccount::from(account)))
             }
         })
+        .collect()
 }
 
 pub(crate) enum VmExecutionError {
@@ -467,13 +472,13 @@ impl<S: Storage> Database for VmDb<'_, S> {
 pub(crate) struct Vm<'a, S: Storage, C: PevmChain> {
     // Shared block-level state
     chain: &'a C,
+    is_eip_161_enabled: bool,
     block_env: &'a BlockEnv,
     txs: &'a [C::EvmTx],
     mv_memory: &'a MvMemory,
     beneficiary_location_hash: MemoryLocationHash,
     // Dedicated EVM for the worker, reset before each transaction exectution.
     evm: C::Evm<VmDb<'a, S>>,
-    is_eip_161_enabled: bool,
 }
 
 impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
@@ -505,6 +510,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
         };
         Self {
             chain,
+            is_eip_161_enabled: chain.is_eip_161_enabled(spec_id),
             block_env,
             txs,
             mv_memory,
@@ -512,7 +518,6 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                 block_env.beneficiary,
             )),
             evm: chain.build_evm(spec_id, block_env.clone(), db),
-            is_eip_161_enabled: chain.is_eip_161_enabled(spec_id),
         }
     }
 
@@ -572,11 +577,9 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                 let mut write_set = WriteSet::with_capacity(6);
 
                 let ctx = self.evm.ctx();
+                let state = ctx.journal_mut().finalize();
 
-                let result_and_state =
-                    ResultAndState::new(exec_result, ctx.journal_mut().finalize());
-
-                for (address, account) in &result_and_state.state {
+                for (address, account) in &state {
                     if account.is_selfdestructed() {
                         // TODO: Also write [SelfDestructed] to the basic location?
                         // For now we are betting on [code_hash] triggering the sequential
@@ -673,7 +676,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                 }
                 let rewards = self.chain.get_rewards(
                     self.beneficiary_location_hash,
-                    U256::from(result_and_state.result.tx_gas_used()),
+                    U256::from(exec_result.tx_gas_used()),
                     U256::from(gas_price),
                     self.block_env.basefee,
                     full_tx,
@@ -720,21 +723,14 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     flags |= FinishExecFlags::WroteNewLocation;
                 }
 
-                let ResultAndState { result, state } = result_and_state;
-                match result_slot {
-                    Some(slot) => {
-                        slot.receipt = receipt_from_revm(result);
-                        slot.state.clear();
-                        slot.state
-                            .extend(state_transitions_from_revm(self.is_eip_161_enabled, state));
-                    }
-                    None => {
-                        *result_slot = Some(PevmTxExecutionResult {
-                            receipt: receipt_from_revm(result),
-                            state: state_transitions_from_revm(self.is_eip_161_enabled, state)
-                                .collect(),
-                        });
-                    }
+                let receipt = receipt_from_revm(exec_result);
+                let state = state_transitions_from_revm(self.is_eip_161_enabled, state);
+                if let Some(slot) = result_slot {
+                    slot.receipt = receipt;
+                    slot.state.clear();
+                    slot.state.extend(state);
+                } else {
+                    *result_slot = Some(PevmTxExecutionResult { receipt, state });
                 }
                 Ok(flags)
             }


### PR DESCRIPTION
## Summary

- Replace `Vec<Mutex<Option<PevmTxExecutionResult>>>` with
  `Vec<UnsafeCell<Option<PevmTxExecutionResult>>>` — the scheduler
  already prevents concurrent writes to the same index, so the lock buys
  nothing.
- Add `unsafe impl Sync for Pevm` (required since `UnsafeCell` is not
  `Sync`); the safety invariant is documented on the field.
- Replace `index_mutex!` call-sites in `execute_revm_parallel` and
  `try_execute` with direct `get_unchecked` + pointer write.
- Replace `take().unwrap()` with `let-else` returning `UnreachableError`
  for a cleaner error path.