### PR TITLE
feat: vendor op-revm into pevm and bump revm to v39

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,14 +66,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8c24c95e90c1608c2d91cff1b451d796474168d3310ccc8b7cd12502ca8169"
+checksum = "83447eeb17816e172f1dfc0db1f9dc0b7c5d069bd1f7cecbecceb382bf931015"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
@@ -88,20 +88,20 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d211ad0ef468a70a7a829e49683ff59ad25f02b4ab3764344c4c2663329a52c"
+checksum = "5406343e306856dc2be762700e98a16904de45dee14a07f233e742ce68daff2f"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "serde",
 ]
 
@@ -115,7 +115,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -141,58 +141,50 @@ dependencies = [
  "borsh",
  "k256",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407510740da514b694fecb44d8b3cebdc60d448f70cc5d24743e8ba273448a6e"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
  "once_cell",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
-name = "alloy-eips"
-version = "1.8.3"
+name = "alloy-eip7928"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
+checksum = "4d93ce7e41bcd2b9ee2c1d92c223c1be4a274d387538d6d3f956b768986ce451"
 dependencies = [
- "alloy-eip2124",
- "alloy-eip2930",
- "alloy-eip7702",
- "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 1.8.3",
- "auto_impl",
  "borsh",
- "c-kzg",
- "derive_more",
- "either",
+ "once_cell",
  "serde",
- "serde_with",
- "sha2",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae69eaa5096b47ffe97e6a5d6bde7e7fa2dec106af22a9315621d11039c3de3c"
+checksum = "0dca4c89ace90684b4b77366d00631ed498c9af962079af2a5dbc593a0618a77"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -205,13 +197,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39789db0b3f3bbef0e6549c87bc6842b73886ebabee1405b6941685b1cc34083"
+checksum = "ab0e0fe9e6d1120ad7bb9254c3fc2b9bc80a8df42a033fb626be6559c13d5153"
 dependencies = [
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "alloy-trie",
  "borsh",
  "serde",
@@ -220,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -232,34 +224,34 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662b525af73e86b2167dae923261c8edf440ba7e1426b30a8b993177bc214c02"
+checksum = "ec0a82e56b1843bce483942d54fcadea92e676f1bde162e93c7d3b621fabc4e1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c657c2d9751d3c7d94990554b231e5372c3c2e4bad842806280b6151a0d6a05d"
+checksum = "a7db7b095b0b1db1d18ce7e91dcd2e82007f2d52bfb8125e6b64633a74a06bc3"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-any",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "alloy-signer",
  "alloy-sol-types",
  "async-trait",
@@ -268,27 +260,27 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e7c4bb0ebbd6d7406d2808968f43c0d5186c69c5e58cedcbee7380f4cd1fcf"
+checksum = "cd28d9bfd11729037d194f2b1d43db8642eb3f342032691f4ca96bb745479c3c"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-primitives",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "serde",
 ]
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -296,7 +288,7 @@ dependencies = [
  "const-hex",
  "derive_more",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
  "k256",
@@ -307,19 +299,20 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4fea0fc2628cdbc851aaa333124f9d8ab9f567ab8d4c20202819db13aa1a534"
+checksum = "8955ab30418343de57b356de2ea60200f9fb8016a7ea3bc7f5c6176f01a8b1cf"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-json-rpc",
  "alloy-network",
  "alloy-network-primitives",
@@ -345,7 +338,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "url",
@@ -376,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ee7b51752c68fb95f21705e402700750e692b1d21ccc294ac48fadc8655d53"
+checksum = "24f461f091dc8f657e73b5dea18fd63d5c7049720cd252f1eade4a7ebed6a7e1"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -399,24 +392,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1a9a3bda9be7f6515316eb792710532411878bbfc88934973f4b371376b00d"
+checksum = "0a6561ed4759c974d9c144500a59e3fb8c1d87327a12900d5ce455c0cae6dcb6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea21739e232c221779741eba7e7b9bc19ad8ff777b72736647ae519f5c9f6f33"
+checksum = "48b9ad6eee93dd35a9ec0a6c1c6b180892a900ee17a6ed6500921552dd71e846"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -427,55 +420,44 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda4ece0050154ab278241aeffade58916b04f38254832e8cb6e4671c6e72ed2"
+checksum = "175a2a5b6017d7f61b5e4b800d21215fe8e94fe729d00828e13bb6d93dcf3492"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5905ac3663b0859d67b82d912acce20887d20682a0cadde79c8a763b133a515"
+checksum = "514b4b1ce3354f65067b4fc7eb75358e0f2ec8be3340c96dea65d6894f9ca435"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.8.3"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
-dependencies = [
- "alloy-primitives",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "alloy-serde"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beaa5c581a67e2743d95b4849eb9cfeb90866429cdaa6d8f6b75eb988b2d0cd9"
+checksum = "cc21a8772af7d78bba286726aa245bd2ff81cd9abe230afea2e91578996831c9"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -484,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5da9ae50f9b48d7b4e2e5cde87175257be7e5e56909a7794720597c1d9806f6"
+checksum = "8ffbce94c50dd9d4d1f83e044c5595bbd3ada981bd3057ce28b3a5470e77385d"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -494,14 +476,14 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -513,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -531,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "const-hex",
  "dunce",
@@ -547,19 +529,19 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -569,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19dec9bfb59647254afdecbb5ddcddd7ba02edcd48ffa40510bddfbed0be1634"
+checksum = "86052fdcec72d37ca4aa4b66254601e7453c45a6e1c70aa4561033d002fb80cc"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -582,7 +564,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tower",
  "tracing",
@@ -592,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2035f3c4d6bee20624da2dcf765d469b292398e48d766ffade61b0fcf8b4d45d"
+checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -618,15 +600,15 @@ dependencies = [
  "nybbles",
  "serde",
  "smallvec",
- "thiserror 2.0.18",
+ "thiserror",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.0.1"
+version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3520337f3d3d063a7fe20f47aaa62d695e3dc0372b34f601560dee24e76988b9"
+checksum = "01a0035943b75fe1e249f52e688492d7a1b1826bc2d19b8e1d5d3c24a2ad8f50"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1078,15 +1060,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1094,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1174,15 +1156,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -1217,6 +1199,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1256,10 +1247,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "bumpalo"
-version = "3.20.2"
+name = "bs58"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1305,21 +1305,15 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -1434,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c83592369519f73d5731f9c91aa562e213a33cc14bb0f27ac2f5730fd1ecbcec"
+checksum = "57af92d1db7f6871b7e82c79cd87f2501db66f36b0eab924be6ea83dd6b2f3f3"
 dependencies = [
  "anyhow",
  "cc",
@@ -1452,9 +1446,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab07c1eb2dbfa1dfeca02f86d2325106886f5d41ea294adf3740f56da7bb2c1a"
+checksum = "1d31ae2e9ab23c29fa13bdfa06d012524176f5c0f4e25ec262cd829d947ebc5e"
 dependencies = [
  "clap",
  "codspeed",
@@ -1465,9 +1459,9 @@ dependencies = [
 
 [[package]]
 name = "codspeed-criterion-compat-walltime"
-version = "4.5.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1601803d919d1bca7338b98948a319f0e40275c304516792aeabdd98db6dcd4f"
+checksum = "cc8605e40bab5114dcb0f76268e18880082b5798dec10757b5b58d2c3bbc7a1c"
 dependencies = [
  "anes",
  "cast",
@@ -1557,9 +1551,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.18.1"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1776,6 +1770,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1925,17 +1928,27 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
 
 [[package]]
-name = "displaydoc"
-version = "0.2.5"
+name = "digest"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1983,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -2347,9 +2360,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2406,15 +2419,13 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
- "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2461,9 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2499,10 +2510,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "hyper"
-version = "1.9.0"
+name = "hybrid-array"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb92f162bf56536459fc83c79b974bb12837acfed43d6bc370a7916d0ae15ecc"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2690,9 +2710,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2742,7 +2762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2765,16 +2785,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is-terminal"
@@ -2828,27 +2838,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2882,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2908,11 +2923,12 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -2987,9 +3003,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "lru"
@@ -3008,9 +3024,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3019,9 +3035,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -3073,14 +3089,23 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nonmax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -3118,9 +3143,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3247,19 +3272,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ca73133d6cb8d0b1cd042433bca9a394e4eaeb8ec1f96c210adf3f45cb74040"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-network",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "bytes",
  "derive_more",
  "reth-codecs",
  "reth-zstd-compressors",
  "serde",
  "serde_with",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -3283,29 +3308,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e322e7437d5fb4aea6d98879046d42516137fe489d867a1b0d53275da76cbd2d"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-network",
  "alloy-network-primitives",
  "alloy-primitives",
  "alloy-rpc-types-eth",
- "alloy-serde 2.0.1",
+ "alloy-serde",
  "derive_more",
  "op-alloy-consensus",
  "reth-rpc-traits",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
-name = "op-revm"
-version = "19.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c545fc4e916747afe36bcf36d6f8b46255b6a1b688f5ca8016e449f258e510"
-dependencies = [
- "auto_impl",
- "revm",
- "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -3432,11 +3446,10 @@ dependencies = [
  "criterion",
  "dashmap",
  "flate2",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "op-alloy-consensus",
  "op-alloy-network",
  "op-alloy-rpc-types",
- "op-revm",
  "rand 0.10.1",
  "rayon",
  "reqwest",
@@ -3449,7 +3462,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "snmalloc-rs",
- "thiserror 2.0.18",
+ "thiserror",
  "tikv-jemallocator",
  "tokio",
  "walkdir",
@@ -3520,18 +3533,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3748,7 +3761,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -3770,7 +3783,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4003,9 +4016,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
  "base64",
  "bytes",
@@ -4048,7 +4061,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce542a96bf888f31854803e80b3340bc233927743aa580838014e8a88fe0d66"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-trie",
@@ -4078,7 +4091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee12e304adbacbb32248c9806ebafbe1e2811fbfefe53c5e5b710a8438b7ec0"
 dependencies = [
  "alloy-consensus",
- "alloy-eips 2.0.1",
+ "alloy-eips",
  "alloy-genesis",
  "alloy-primitives",
  "alloy-rlp",
@@ -4088,12 +4101,12 @@ dependencies = [
  "derive_more",
  "once_cell",
  "quanta",
- "revm-bytecode",
- "revm-primitives",
- "revm-state",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
+ "revm-state 11.0.1",
  "secp256k1 0.30.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4108,7 +4121,7 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-signer",
  "reth-primitives-traits",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -4122,11 +4135,11 @@ dependencies = [
 
 [[package]]
 name = "revm"
-version = "38.0.0"
+version = "39.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91202d39dbe8e8d10e9e8f2b76c30da68ecd1d25be69ba6d853ad0d03a3a398a"
+checksum = "e173824bae3f22191b2d33f86945d9f82945638d0135d548c0b87850cc0b1934"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 11.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database",
@@ -4135,8 +4148,8 @@ dependencies = [
  "revm-inspector",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "revm-statetest-types",
 ]
 
@@ -4147,97 +4160,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdbb3a3d735efa94c91f2ef6bf20a35f99a77bc78f3e25bd758336901bdf9661"
 dependencies = [
  "bitvec",
+ "phf",
+ "revm-primitives 23.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-bytecode"
+version = "11.0.0"
+source = "git+https://github.com/bluealloy/revm?tag=v108#e0ced3c9c172e43a5cd92448b5142e1d2bfed181"
+dependencies = [
+ "bitvec",
  "paste",
  "phf",
- "revm-primitives",
+ "revm-primitives 24.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context"
-version = "16.0.1"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f68d928d8b228e0faeb1c6ed75c4fde7d124f1ddf9119b67e7a0ad4041237d"
+checksum = "f13f89d92b4fe269c87210e10953c50177e1f44e5da412f071f43d3427be7490"
 dependencies = [
  "bitvec",
  "cfg-if",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 11.0.0",
  "revm-context-interface",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-context-interface"
-version = "17.0.1"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3758e6167c4ba7a59a689c519a047edaefcd4c37d74f279b93ed87bc8aece4"
+checksum = "26d934e9518e30e0c1467733fbebd2f921bf5acffe46b15e8455b52d77adf449"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "auto_impl",
  "either",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-database"
-version = "13.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c281a1f11d3bcb8c0bba1199ed6bcb001d1aeb3d4fb366819e14f88723989a4e"
+version = "14.0.0"
+source = "git+https://github.com/bluealloy/revm?tag=v108#e0ced3c9c172e43a5cd92448b5142e1d2bfed181"
 dependencies = [
- "alloy-eips 1.8.3",
- "revm-bytecode",
+ "alloy-eips",
+ "revm-bytecode 11.0.0",
  "revm-database-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-database-interface"
-version = "11.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89efb9832a4e3742bb4ded5f7fe5bf905e8860e69427d4dfec153484fc6d304"
+version = "11.1.0"
+source = "git+https://github.com/bluealloy/revm?tag=v108#e0ced3c9c172e43a5cd92448b5142e1d2bfed181"
 dependencies = [
  "auto_impl",
  "either",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "revm-handler"
-version = "18.1.0"
+version = "19.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783e903d6922b7f5f9a940d1bb229530502d2924b1aed9d5ca5a94ebf065d460"
+checksum = "1d8c25a8f54b41f2ce22e516f08e8cf3e85b5db12471fd27a3a7ad9550fb6974"
 dependencies = [
  "auto_impl",
  "derive-where",
- "revm-bytecode",
+ "revm-bytecode 11.0.0",
  "revm-context",
  "revm-context-interface",
  "revm-database-interface",
  "revm-interpreter",
  "revm-precompile",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-inspector"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8216ad58422090d0daa9eb430e0a081f7ad07e7fd30681dee71f8420c99624e0"
+checksum = "df0a3c7df0ebab93b840286f381df91f046f75ab6cb428fee120a2f8f5a8c34a"
 dependencies = [
  "auto_impl",
  "either",
@@ -4245,30 +4267,30 @@ dependencies = [
  "revm-database-interface",
  "revm-handler",
  "revm-interpreter",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "revm-interpreter"
-version = "35.0.1"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ece9f41b69658c15d748288a4dbdfc06a63f3ce93d983af440de3f1631dce6a"
+checksum = "0011accd130c2e66bf1f3fec0f72c78233aa1026367f422cc6f0c23b3d281c59"
 dependencies = [
- "revm-bytecode",
+ "revm-bytecode 11.0.0",
  "revm-context-interface",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-precompile"
-version = "34.0.0"
+version = "35.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a346a8cc6c8c39bd65306641c692191299c0a7b63d38810e39e8fe9b92378660"
+checksum = "673e711d9048f262667800681fa7c46b39c4a759e44510e6f8640550707e469f"
 dependencies = [
  "ark-bls12-381",
  "ark-bn254",
@@ -4283,7 +4305,7 @@ dependencies = [
  "k256",
  "p256",
  "revm-context-interface",
- "revm-primitives",
+ "revm-primitives 24.0.0",
  "ripemd",
  "secp256k1 0.31.1",
  "sha2",
@@ -4302,41 +4324,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "revm-primitives"
+version = "24.0.0"
+source = "git+https://github.com/bluealloy/revm?tag=v108#e0ced3c9c172e43a5cd92448b5142e1d2bfed181"
+dependencies = [
+ "alloy-primitives",
+ "once_cell",
+ "serde",
+]
+
+[[package]]
 name = "revm-state"
 version = "11.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c32490ed687dba31c3c882beb8c20408bdd30ef96690d8f145b0ee9a87040bfe"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.3.7",
  "bitflags",
- "revm-bytecode",
- "revm-primitives",
+ "revm-bytecode 10.0.0",
+ "revm-primitives 23.0.0",
+ "serde",
+]
+
+[[package]]
+name = "revm-state"
+version = "12.0.0"
+source = "git+https://github.com/bluealloy/revm?tag=v108#e0ced3c9c172e43a5cd92448b5142e1d2bfed181"
+dependencies = [
+ "alloy-eip7928 0.4.1",
+ "bitflags",
+ "nonmax",
+ "revm-bytecode 11.0.0",
+ "revm-primitives 24.0.0",
  "serde",
 ]
 
 [[package]]
 name = "revm-statetest-types"
-version = "17.0.1"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94743de1e54a812077b79dd3a87b4059175a804650b21582fb6feae96ef2be9c"
+checksum = "b8af8e35ca976f6a18f4a34b220c6634af713a53d3b102623da9beeaa135c945"
 dependencies = [
- "alloy-eip7928",
+ "alloy-eip7928 0.4.1",
  "k256",
  "revm-context",
  "revm-context-interface",
  "revm-database",
- "revm-primitives",
- "revm-state",
+ "revm-primitives 24.0.0",
+ "revm-state 12.0.0",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
 name = "revme"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a40564bea3b4e83dde3c735e1cf345a6bc0478c2041db9a55ec8a4f5c6754a12"
+checksum = "fd50cfe459de6e03e186dd925e8d2853cea5b7a6bc6d43d235292a105e43fcd7"
 dependencies = [
  "alloy-rlp",
  "alloy-sol-types",
@@ -4349,7 +4394,7 @@ dependencies = [
  "revm",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror",
  "walkdir",
 ]
 
@@ -4501,9 +4546,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -4537,9 +4582,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -4781,9 +4826,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "indexmap 2.14.0",
  "itoa",
@@ -4795,11 +4840,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -4814,9 +4860,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.18.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -4847,11 +4893,11 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
  "keccak",
 ]
 
@@ -4897,10 +4943,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
+name = "simd_cesu8"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -5034,9 +5096,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -5106,31 +5168,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -5250,9 +5292,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5320,14 +5362,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -5336,7 +5378,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow",
 ]
 
 [[package]]
@@ -5356,20 +5398,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -5621,9 +5663,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5634,9 +5676,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5644,9 +5686,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5654,9 +5696,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5667,9 +5709,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5724,9 +5766,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5854,15 +5896,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5895,21 +5928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5947,12 +5965,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5965,12 +5977,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5980,12 +5986,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6013,12 +6013,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -6028,12 +6022,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6049,12 +6037,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -6064,12 +6046,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6085,18 +6061,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -6235,18 +6202,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6255,9 +6222,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,10 +54,9 @@ alloy-transport = "2.0.1"
 alloy-trie = "0.9.5"
 
 # Will remove [revm] with https://github.com/risechain/pevm/issues/382.
-op-revm = "19.0.0"
-revm = { version = "38.0.0", features = ["serde"] }
-revm-statetest-types = "17.0.1"
-revme = "15.0.0"
+revm = { version = "39.0.0", features = ["serde"] }
+revm-statetest-types = "18.0.0"
+revme = "16.0.0"
 
 # OP
 op-alloy-consensus = "2.0.0"
@@ -88,3 +87,14 @@ smallvec = "1.15.1"
 thiserror = "2.0.18"
 tokio = { version = "1.52.1", features = ["rt-multi-thread"] }
 walkdir = "2.5.0"
+
+[patch.crates-io]
+# revm-database-interface 11.1.0 and several companion crates were yanked from crates.io.
+# The git source (tag v108) declares the same version numbers so cargo's semver resolver is
+# satisfied without any API change. We patch the whole set to avoid duplicate-crate ambiguities
+# that arise when mixing crates.io and git sources for interdependent revm subcrates.
+revm-bytecode = { git = "https://github.com/bluealloy/revm", tag = "v108" }
+revm-database = { git = "https://github.com/bluealloy/revm", tag = "v108" }
+revm-database-interface = { git = "https://github.com/bluealloy/revm", tag = "v108" }
+revm-primitives = { git = "https://github.com/bluealloy/revm", tag = "v108" }
+revm-state = { git = "https://github.com/bluealloy/revm", tag = "v108" }

--- a/crates/pevm/Cargo.toml
+++ b/crates/pevm/Cargo.toml
@@ -26,7 +26,6 @@ serde.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 
-op-revm.workspace = true
 revm.workspace = true
 
 op-alloy-consensus.workspace = true

--- a/crates/pevm/src/chain/rise.rs
+++ b/crates/pevm/src/chain/rise.rs
@@ -2,8 +2,8 @@
 use std::sync::LazyLock;
 
 use crate::rise_revm::{
-    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, OpContext, RiseEvm,
-    RiseHaltReason, RiseTransaction, RiseTransactionError, transaction::DepositTransactionParts,
+    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, RiseEvm, RiseHaltReason,
+    RiseTransaction, RiseTransactionError, transaction::DepositTransactionParts,
 };
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, ChainId, U256};
@@ -64,7 +64,7 @@ impl PevmChain for PevmRise {
     type Network = op_alloy_network::Optimism;
     type Transaction = op_alloy_rpc_types::Transaction;
     type Envelope = OpTxEnvelope;
-    type Evm<DB: Database> = RiseEvm<OpContext<DB>>;
+    type Evm<DB: Database> = RiseEvm<DB>;
     type EvmSpecId = SpecId;
     type EvmTx = RiseTransaction<TxEnv>;
     type EvmHaltReason = RiseHaltReason;

--- a/crates/pevm/src/chain/rise.rs
+++ b/crates/pevm/src/chain/rise.rs
@@ -2,8 +2,8 @@
 use std::sync::LazyLock;
 
 use crate::rise_revm::{
-    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, RiseEvm, RiseHaltReason,
-    RiseTransaction, RiseTransactionError, transaction::DepositTransactionParts,
+    BASE_FEE_RECIPIENT, RiseEvm, RiseHaltReason, RiseTransaction, RiseTransactionError,
+    transaction::DepositTransactionParts,
 };
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, ChainId, U256};
@@ -31,12 +31,6 @@ const RISE_CHAIN_ID: ChainId = 4153; // Mainnet
 
 static BASE_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
     LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(BASE_FEE_RECIPIENT)));
-
-static L1_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
-    LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(L1_FEE_RECIPIENT)));
-
-static OPERATOR_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
-    LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(OPERATOR_FEE_RECIPIENT)));
 
 /// Implementation of [`PevmChain`] for RISE
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -66,7 +60,7 @@ impl PevmChain for PevmRise {
     type Envelope = OpTxEnvelope;
     type Evm<DB: Database> = RiseEvm<DB>;
     type EvmSpecId = SpecId;
-    type EvmTx = RiseTransaction<TxEnv>;
+    type EvmTx = RiseTransaction;
     type EvmHaltReason = RiseHaltReason;
     type EvmErrorType = RiseTransactionError;
     type BlockSpecError = std::convert::Infallible;
@@ -104,7 +98,7 @@ impl PevmChain for PevmRise {
         )
     }
 
-    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[RiseTransaction<TxEnv>]) -> MvMemory {
+    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[RiseTransaction]) -> MvMemory {
         let beneficiary_location_hash =
             hash_deterministic(MemoryLocation::Basic(block_env.beneficiary));
 
@@ -124,26 +118,13 @@ impl PevmChain for PevmRise {
                     .entry(*BASE_FEE_RECIPIENT_LOCATION_HASH)
                     .or_insert_with(|| Vec::with_capacity(txs.len()))
                     .push(index);
-                estimated_locations
-                    .entry(*L1_FEE_RECIPIENT_LOCATION_HASH)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
-                estimated_locations
-                    .entry(*OPERATOR_FEE_RECIPIENT_LOCATION_HASH)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
             }
         }
 
         MvMemory::new(
             txs.len(),
             estimated_locations,
-            [
-                block_env.beneficiary,
-                BASE_FEE_RECIPIENT,
-                L1_FEE_RECIPIENT,
-                OPERATOR_FEE_RECIPIENT,
-            ],
+            [block_env.beneficiary, BASE_FEE_RECIPIENT],
         )
     }
 
@@ -167,11 +148,6 @@ impl PevmChain for PevmRise {
                     *BASE_FEE_RECIPIENT_LOCATION_HASH,
                     U256::from(basefee).saturating_mul(gas_used),
                 ),
-                // RISE disables DA footprint and operator fees. Annoyingly, we still
-                // need to touch these to match revm's sequential execution for now.
-                // Will remove once we rewrite our own EVM implementation.
-                (*L1_FEE_RECIPIENT_LOCATION_HASH, U256::ZERO),
-                (*OPERATOR_FEE_RECIPIENT_LOCATION_HASH, U256::ZERO),
             ]
         }
     }
@@ -231,7 +207,7 @@ impl PevmChain for PevmRise {
     fn get_tx_env(
         &self,
         tx: &Self::Transaction,
-    ) -> Result<RiseTransaction<TxEnv>, RiseTransactionParsingError> {
+    ) -> Result<RiseTransaction, RiseTransactionParsingError> {
         Ok(RiseTransaction {
             base: TxEnv {
                 tx_type: tx.inner.inner.tx_type().into(),
@@ -264,12 +240,12 @@ impl PevmChain for PevmRise {
                     deposit.is_system_transaction,
                 )
             } else {
-                DepositTransactionParts::new(B256::ZERO, None, false)
+                DepositTransactionParts::default()
             },
         })
     }
 
-    fn tx_env<'a>(&self, tx: &'a RiseTransaction<TxEnv>) -> &'a TxEnv {
+    fn tx_env<'a>(&self, tx: &'a RiseTransaction) -> &'a TxEnv {
         &tx.base
     }
 

--- a/crates/pevm/src/chain/rise.rs
+++ b/crates/pevm/src/chain/rise.rs
@@ -1,23 +1,22 @@
 //! RISE
 use std::sync::LazyLock;
 
+use crate::rise_revm::{
+    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, OpContext, RiseEvm,
+    RiseHaltReason, RiseTransaction, RiseTransactionError, transaction::DepositTransactionParts,
+};
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, ChainId, U256};
 use alloy_rpc_types_eth::{BlockTransactions, Header};
 use hashbrown::HashMap;
 use op_alloy_consensus::{OpDepositReceipt, OpReceiptEnvelope, OpTxEnvelope, OpTxType};
 use op_alloy_network::eip2718::Encodable2718;
-use op_revm::{
-    L1BlockInfo, OpBuilder, OpContext, OpEvm, OpHaltReason, OpSpecId, OpTransaction,
-    OpTransactionError,
-    constants::{BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT},
-    transaction::{OpTxTr, deposit::DepositTransactionParts},
-};
 use revm::{
     Context, Database, MainContext,
     context::{BlockEnv, CfgEnv, TxEnv},
     context_interface::either::Either,
     handler::EvmTr,
+    primitives::hardfork::SpecId,
 };
 use smallvec::SmallVec;
 
@@ -65,11 +64,11 @@ impl PevmChain for PevmRise {
     type Network = op_alloy_network::Optimism;
     type Transaction = op_alloy_rpc_types::Transaction;
     type Envelope = OpTxEnvelope;
-    type Evm<DB: Database> = OpEvm<OpContext<DB>, ()>;
-    type EvmSpecId = OpSpecId;
-    type EvmTx = OpTransaction<TxEnv>;
-    type EvmHaltReason = OpHaltReason;
-    type EvmErrorType = OpTransactionError;
+    type Evm<DB: Database> = RiseEvm<OpContext<DB>>;
+    type EvmSpecId = SpecId;
+    type EvmTx = RiseTransaction<TxEnv>;
+    type EvmHaltReason = RiseHaltReason;
+    type EvmErrorType = RiseTransactionError;
     type BlockSpecError = std::convert::Infallible;
     type TransactionParsingError = RiseTransactionParsingError;
 
@@ -85,9 +84,8 @@ impl PevmChain for PevmRise {
         }
     }
 
-    fn get_block_spec(&self, _header: &Header) -> Result<OpSpecId, Self::BlockSpecError> {
-        // RISE Mainnet launched as JOVIAN; currently all blocks use this spec.
-        Ok(OpSpecId::JOVIAN)
+    fn get_block_spec(&self, _header: &Header) -> Result<SpecId, Self::BlockSpecError> {
+        Ok(SpecId::PRAGUE)
     }
 
     fn build_evm<DB: Database>(
@@ -96,16 +94,17 @@ impl PevmChain for PevmRise {
         block_env: BlockEnv,
         db: DB,
     ) -> Self::Evm<DB> {
-        Context::mainnet()
-            .with_cfg(CfgEnv::new_with_spec(spec_id).with_chain_id(RISE_CHAIN_ID))
-            .with_block(block_env)
-            .with_db(db)
-            .with_tx(OpTransaction::default())
-            .with_chain(L1BlockInfo::default())
-            .build_op()
+        RiseEvm::new(
+            Context::mainnet()
+                .with_cfg(CfgEnv::new_with_spec(spec_id).with_chain_id(RISE_CHAIN_ID))
+                .with_block(block_env)
+                .with_db(db)
+                .with_tx(RiseTransaction::default())
+                .with_chain(()),
+        )
     }
 
-    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[OpTransaction<TxEnv>]) -> MvMemory {
+    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[RiseTransaction<TxEnv>]) -> MvMemory {
         let beneficiary_location_hash =
             hash_deterministic(MemoryLocation::Basic(block_env.beneficiary));
 
@@ -182,7 +181,7 @@ impl PevmChain for PevmRise {
     // https://github.com/paradigmxyz/reth/blob/b4a1b733c93f7e262f1b774722670e08cdcb6276/crates/primitives/src/proofs.rs
     fn calculate_receipt_root(
         &self,
-        _: OpSpecId,
+        _: SpecId,
         txs: &BlockTransactions<Self::Transaction>,
         tx_results: &[PevmTxExecutionResult],
     ) -> Result<B256, CalculateReceiptRootError> {
@@ -232,8 +231,8 @@ impl PevmChain for PevmRise {
     fn get_tx_env(
         &self,
         tx: &Self::Transaction,
-    ) -> Result<OpTransaction<TxEnv>, RiseTransactionParsingError> {
-        Ok(OpTransaction {
+    ) -> Result<RiseTransaction<TxEnv>, RiseTransactionParsingError> {
+        Ok(RiseTransaction {
             base: TxEnv {
                 tx_type: tx.inner.inner.tx_type().into(),
                 caller: tx.inner.inner.signer(),
@@ -270,7 +269,7 @@ impl PevmChain for PevmRise {
         })
     }
 
-    fn tx_env<'a>(&self, tx: &'a OpTransaction<TxEnv>) -> &'a TxEnv {
+    fn tx_env<'a>(&self, tx: &'a RiseTransaction<TxEnv>) -> &'a TxEnv {
         &tx.base
     }
 
@@ -281,11 +280,11 @@ impl PevmChain for PevmRise {
         !is_deposit
     }
 
-    fn is_eip_1559_enabled(&self, _: OpSpecId) -> bool {
+    fn is_eip_1559_enabled(&self, _: SpecId) -> bool {
         true
     }
 
-    fn is_eip_161_enabled(&self, _: OpSpecId) -> bool {
+    fn is_eip_161_enabled(&self, _: SpecId) -> bool {
         true
     }
 }

--- a/crates/pevm/src/chain/rise.rs
+++ b/crates/pevm/src/chain/rise.rs
@@ -234,11 +234,11 @@ impl PevmChain for PevmRise {
                 Some(tx.inner.inner.encoded_2718().into())
             },
             deposit: if let Some(deposit) = tx.inner.inner.as_deposit() {
-                DepositTransactionParts::new(
-                    deposit.source_hash,
-                    Some(deposit.mint),
-                    deposit.is_system_transaction,
-                )
+                DepositTransactionParts {
+                    source_hash: deposit.source_hash,
+                    mint: Some(deposit.mint),
+                    is_system_transaction: deposit.is_system_transaction,
+                }
             } else {
                 DepositTransactionParts::default()
             },

--- a/crates/pevm/src/lib.rs
+++ b/crates/pevm/src/lib.rs
@@ -218,6 +218,7 @@ pub mod chain;
 mod compat;
 mod mv_memory;
 mod pevm;
+pub(crate) mod rise_revm;
 pub use pevm::{Pevm, PevmError, PevmResult, execute_revm_sequential};
 mod scheduler;
 mod storage;

--- a/crates/pevm/src/rise_revm/evm.rs
+++ b/crates/pevm/src/rise_revm/evm.rs
@@ -4,7 +4,7 @@ use super::{
 };
 use revm::{
     Database, ExecuteEvm,
-    context::{BlockEnv, ContextError, ContextSetters, Evm, FrameStack, TxEnv},
+    context::{BlockEnv, ContextError, ContextSetters, Evm, FrameStack},
     context_interface::{
         ContextTr,
         result::{EVMError, ExecResultAndState, ExecutionResult},
@@ -93,7 +93,7 @@ impl<DB: Database> EvmTr for RiseEvm<DB> {
 }
 
 impl<DB: Database> ExecuteEvm for RiseEvm<DB> {
-    type Tx = RiseTransaction<TxEnv>;
+    type Tx = RiseTransaction;
     type Block = BlockEnv;
     type State = EvmState;
     type Error = RiseError<DB>;

--- a/crates/pevm/src/rise_revm/evm.rs
+++ b/crates/pevm/src/rise_revm/evm.rs
@@ -1,57 +1,54 @@
-use super::precompiles::OpPrecompiles;
-use super::{OpContext, OpContextTr, RiseHaltReason, RiseTransactionError, handler::OpHandler};
+use super::precompiles::RisePrecompiles;
+use super::{
+    RiseContext, RiseHaltReason, RiseTransaction, RiseTransactionError, handler::RiseHandler,
+};
 use revm::{
     Database, ExecuteEvm,
-    context::{Cfg, ContextError, ContextSetters, Evm, FrameStack},
+    context::{BlockEnv, ContextError, ContextSetters, Evm, FrameStack, TxEnv},
     context_interface::{
-        ContextTr, JournalTr,
+        ContextTr,
         result::{EVMError, ExecResultAndState, ExecutionResult},
     },
     handler::{
-        EthFrame, EvmTr, FrameInitOrResult, Handler, ItemOrResult, PrecompileProvider,
-        evm::FrameTr,
-        instructions::{EthInstructions, InstructionProvider},
+        EthFrame, EvmTr, FrameInitOrResult, FrameResult, Handler, ItemOrResult, evm::FrameTr,
+        instructions::EthInstructions,
     },
-    interpreter::{InterpreterResult, interpreter::EthInterpreter},
-    primitives::hardfork::SpecId,
+    interpreter::interpreter::EthInterpreter,
     state::EvmState,
 };
 
-pub(crate) type OpError<DB> = EVMError<<DB as Database>::Error, RiseTransactionError>;
+pub(crate) type RiseError<DB> = EVMError<<DB as Database>::Error, RiseTransactionError>;
 
 /// RISE EVM wrapping [`Evm`] with RISE-specific precompiles and handler dispatch.
 #[derive(Debug)]
-pub struct RiseEvm<CTX>(
-    Evm<CTX, (), EthInstructions<EthInterpreter, CTX>, OpPrecompiles, EthFrame<EthInterpreter>>,
+#[allow(clippy::type_complexity)]
+pub struct RiseEvm<DB: Database>(
+    Evm<
+        RiseContext<DB>,
+        (),
+        EthInstructions<EthInterpreter, RiseContext<DB>>,
+        RisePrecompiles,
+        EthFrame<EthInterpreter>,
+    >,
 );
 
-impl<DB: Database> RiseEvm<OpContext<DB>>
-where
-    OpContext<DB>: ContextTr<Db = DB>,
-    <OpContext<DB> as ContextTr>::Cfg: Cfg<Spec = SpecId>,
-{
-    pub(crate) fn new(ctx: OpContext<DB>) -> Self {
-        let spec = ctx.cfg().spec();
+impl<DB: Database> RiseEvm<DB> {
+    pub(crate) fn new(ctx: RiseContext<DB>) -> Self {
+        let spec = *ctx.cfg().spec();
         Self(Evm {
             ctx,
             inspector: (),
             instruction: EthInstructions::new_mainnet_with_spec(spec),
-            precompiles: OpPrecompiles::default(),
+            precompiles: RisePrecompiles::default(),
             frame_stack: FrameStack::new_prealloc(8),
         })
     }
 }
 
-impl<DB: Database> EvmTr for RiseEvm<OpContext<DB>>
-where
-    OpContext<DB>: ContextTr<Db = DB>,
-    EthInstructions<EthInterpreter, OpContext<DB>>:
-        InstructionProvider<Context = OpContext<DB>, InterpreterTypes = EthInterpreter>,
-    OpPrecompiles: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
-{
-    type Context = OpContext<DB>;
-    type Instructions = EthInstructions<EthInterpreter, OpContext<DB>>;
-    type Precompiles = OpPrecompiles;
+impl<DB: Database> EvmTr for RiseEvm<DB> {
+    type Context = RiseContext<DB>;
+    type Instructions = EthInstructions<EthInterpreter, RiseContext<DB>>;
+    type Precompiles = RisePrecompiles;
     type Frame = EthFrame<EthInterpreter>;
 
     fn all(
@@ -79,10 +76,7 @@ where
     fn frame_init(
         &mut self,
         frame_input: <Self::Frame as FrameTr>::FrameInit,
-    ) -> Result<
-        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
-        ContextError<DB::Error>,
-    > {
+    ) -> Result<ItemOrResult<&mut Self::Frame, FrameResult>, ContextError<DB::Error>> {
         self.0.frame_init(frame_input)
     }
 
@@ -92,23 +86,17 @@ where
 
     fn frame_return_result(
         &mut self,
-        result: <Self::Frame as FrameTr>::FrameResult,
-    ) -> Result<Option<<Self::Frame as FrameTr>::FrameResult>, ContextError<DB::Error>> {
+        result: FrameResult,
+    ) -> Result<Option<FrameResult>, ContextError<DB::Error>> {
         self.0.frame_return_result(result)
     }
 }
 
-impl<DB: Database> ExecuteEvm for RiseEvm<OpContext<DB>>
-where
-    OpContext<DB>: ContextTr<Db = DB> + OpContextTr + ContextSetters,
-    EthInstructions<EthInterpreter, OpContext<DB>>:
-        InstructionProvider<Context = OpContext<DB>, InterpreterTypes = EthInterpreter>,
-    OpPrecompiles: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
-{
-    type Tx = <OpContext<DB> as ContextTr>::Tx;
-    type Block = <OpContext<DB> as ContextTr>::Block;
+impl<DB: Database> ExecuteEvm for RiseEvm<DB> {
+    type Tx = RiseTransaction<TxEnv>;
+    type Block = BlockEnv;
     type State = EvmState;
-    type Error = OpError<DB>;
+    type Error = RiseError<DB>;
     type ExecutionResult = ExecutionResult<RiseHaltReason>;
 
     fn set_block(&mut self, block: Self::Block) {
@@ -117,7 +105,7 @@ where
 
     fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
         self.0.ctx.set_tx(tx);
-        OpHandler::default().run(self)
+        RiseHandler::default().run(self)
     }
 
     fn finalize(&mut self) -> Self::State {
@@ -127,9 +115,8 @@ where
     fn replay(
         &mut self,
     ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
-        OpHandler::<_, _>::default().run(self).map(|result| {
-            let state = self.finalize();
-            ExecResultAndState::new(result, state)
-        })
+        RiseHandler::default()
+            .run(self)
+            .map(|result| ExecResultAndState::new(result, self.finalize()))
     }
 }

--- a/crates/pevm/src/rise_revm/evm.rs
+++ b/crates/pevm/src/rise_revm/evm.rs
@@ -1,0 +1,135 @@
+use super::precompiles::OpPrecompiles;
+use super::{OpContext, OpContextTr, RiseHaltReason, RiseTransactionError, handler::OpHandler};
+use revm::{
+    Database, ExecuteEvm,
+    context::{Cfg, ContextError, ContextSetters, Evm, FrameStack},
+    context_interface::{
+        ContextTr, JournalTr,
+        result::{EVMError, ExecResultAndState, ExecutionResult},
+    },
+    handler::{
+        EthFrame, EvmTr, FrameInitOrResult, Handler, ItemOrResult, PrecompileProvider,
+        evm::FrameTr,
+        instructions::{EthInstructions, InstructionProvider},
+    },
+    interpreter::{InterpreterResult, interpreter::EthInterpreter},
+    primitives::hardfork::SpecId,
+    state::EvmState,
+};
+
+pub(crate) type OpError<DB> = EVMError<<DB as Database>::Error, RiseTransactionError>;
+
+/// RISE EVM wrapping [`Evm`] with RISE-specific precompiles and handler dispatch.
+#[derive(Debug)]
+pub struct RiseEvm<CTX>(
+    Evm<CTX, (), EthInstructions<EthInterpreter, CTX>, OpPrecompiles, EthFrame<EthInterpreter>>,
+);
+
+impl<DB: Database> RiseEvm<OpContext<DB>>
+where
+    OpContext<DB>: ContextTr<Db = DB>,
+    <OpContext<DB> as ContextTr>::Cfg: Cfg<Spec = SpecId>,
+{
+    pub(crate) fn new(ctx: OpContext<DB>) -> Self {
+        let spec = ctx.cfg().spec();
+        Self(Evm {
+            ctx,
+            inspector: (),
+            instruction: EthInstructions::new_mainnet_with_spec(spec),
+            precompiles: OpPrecompiles::default(),
+            frame_stack: FrameStack::new_prealloc(8),
+        })
+    }
+}
+
+impl<DB: Database> EvmTr for RiseEvm<OpContext<DB>>
+where
+    OpContext<DB>: ContextTr<Db = DB>,
+    EthInstructions<EthInterpreter, OpContext<DB>>:
+        InstructionProvider<Context = OpContext<DB>, InterpreterTypes = EthInterpreter>,
+    OpPrecompiles: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+{
+    type Context = OpContext<DB>;
+    type Instructions = EthInstructions<EthInterpreter, OpContext<DB>>;
+    type Precompiles = OpPrecompiles;
+    type Frame = EthFrame<EthInterpreter>;
+
+    fn all(
+        &self,
+    ) -> (
+        &Self::Context,
+        &Self::Instructions,
+        &Self::Precompiles,
+        &FrameStack<Self::Frame>,
+    ) {
+        self.0.all()
+    }
+
+    fn all_mut(
+        &mut self,
+    ) -> (
+        &mut Self::Context,
+        &mut Self::Instructions,
+        &mut Self::Precompiles,
+        &mut FrameStack<Self::Frame>,
+    ) {
+        self.0.all_mut()
+    }
+
+    fn frame_init(
+        &mut self,
+        frame_input: <Self::Frame as FrameTr>::FrameInit,
+    ) -> Result<
+        ItemOrResult<&mut Self::Frame, <Self::Frame as FrameTr>::FrameResult>,
+        ContextError<DB::Error>,
+    > {
+        self.0.frame_init(frame_input)
+    }
+
+    fn frame_run(&mut self) -> Result<FrameInitOrResult<Self::Frame>, ContextError<DB::Error>> {
+        self.0.frame_run()
+    }
+
+    fn frame_return_result(
+        &mut self,
+        result: <Self::Frame as FrameTr>::FrameResult,
+    ) -> Result<Option<<Self::Frame as FrameTr>::FrameResult>, ContextError<DB::Error>> {
+        self.0.frame_return_result(result)
+    }
+}
+
+impl<DB: Database> ExecuteEvm for RiseEvm<OpContext<DB>>
+where
+    OpContext<DB>: ContextTr<Db = DB> + OpContextTr + ContextSetters,
+    EthInstructions<EthInterpreter, OpContext<DB>>:
+        InstructionProvider<Context = OpContext<DB>, InterpreterTypes = EthInterpreter>,
+    OpPrecompiles: PrecompileProvider<OpContext<DB>, Output = InterpreterResult>,
+{
+    type Tx = <OpContext<DB> as ContextTr>::Tx;
+    type Block = <OpContext<DB> as ContextTr>::Block;
+    type State = EvmState;
+    type Error = OpError<DB>;
+    type ExecutionResult = ExecutionResult<RiseHaltReason>;
+
+    fn set_block(&mut self, block: Self::Block) {
+        self.0.ctx.set_block(block);
+    }
+
+    fn transact_one(&mut self, tx: Self::Tx) -> Result<Self::ExecutionResult, Self::Error> {
+        self.0.ctx.set_tx(tx);
+        OpHandler::default().run(self)
+    }
+
+    fn finalize(&mut self) -> Self::State {
+        self.0.ctx.journal_mut().finalize()
+    }
+
+    fn replay(
+        &mut self,
+    ) -> Result<ExecResultAndState<Self::ExecutionResult, Self::State>, Self::Error> {
+        OpHandler::<_, _>::default().run(self).map(|result| {
+            let state = self.finalize();
+            ExecResultAndState::new(result, state)
+        })
+    }
+}

--- a/crates/pevm/src/rise_revm/handler.rs
+++ b/crates/pevm/src/rise_revm/handler.rs
@@ -1,0 +1,271 @@
+use crate::rise_revm::{
+    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, OpContextTr, RiseHaltReason,
+    transaction::{DEPOSIT_TRANSACTION_TYPE, RiseTransactionError},
+};
+use revm::{
+    context::{
+        LocalContextTr,
+        journaled_state::{JournalCheckpoint, account::JournaledAccountTr},
+    },
+    context_interface::{
+        Block, Cfg, ContextTr, JournalTr, Transaction,
+        context::take_error,
+        result::{EVMError, ExecutionResult, FromStringError, ResultGas},
+    },
+    handler::{
+        EthFrame, EvmTr, Handler, MainnetHandler,
+        evm::FrameTr,
+        handler::EvmTrError,
+        post_execution::{self, reimburse_caller},
+        pre_execution::{calculate_caller_fee, validate_account_nonce_and_code_with_components},
+    },
+    interpreter::{Gas, InitialAndFloorGas, interpreter::EthInterpreter},
+    primitives::U256,
+};
+use std::vec::Vec;
+
+/// Helper to identify transaction-level errors (used in `catch_error`).
+pub(crate) trait IsTxError {
+    fn is_tx_error(&self) -> bool;
+}
+
+impl<DB, TX> IsTxError for EVMError<DB, TX> {
+    fn is_tx_error(&self) -> bool {
+        matches!(self, Self::Transaction(_))
+    }
+}
+
+/// Wraps [`MainnetHandler`] and overrides the methods that differ for OP Stack chains:
+/// deposit transaction handling, gas accounting, and fee distribution.
+#[derive(Debug)]
+pub(crate) struct OpHandler<EVM, ERROR>(MainnetHandler<EVM, ERROR, EthFrame<EthInterpreter>>);
+
+impl<EVM, ERROR> Default for OpHandler<EVM, ERROR> {
+    fn default() -> Self {
+        Self(MainnetHandler::default())
+    }
+}
+
+impl<EVM, ERROR> Handler for OpHandler<EVM, ERROR>
+where
+    EVM: EvmTr<Context: OpContextTr, Frame = EthFrame<EthInterpreter>>,
+    ERROR: EvmTrError<EVM> + From<RiseTransactionError> + FromStringError + IsTxError,
+{
+    type Evm = EVM;
+    type Error = ERROR;
+    type HaltReason = RiseHaltReason;
+
+    fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
+        let ctx = evm.ctx();
+        let tx = ctx.tx();
+
+        if tx.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            // System transactions are rejected post-Regolith; RISE is always post-Regolith.
+            if tx.is_system_transaction() {
+                return Err(RiseTransactionError::DepositSystemTxPostRegolith.into());
+            }
+            return Ok(());
+        }
+
+        // Non-deposits must carry enveloped bytes for L1 cost computation.
+        if tx.enveloped_tx().is_none() {
+            return Err(RiseTransactionError::MissingEnvelopedTx.into());
+        }
+
+        self.0.validate_env(evm)
+    }
+
+    fn validate_against_state_and_deduct_caller(
+        &self,
+        evm: &mut Self::Evm,
+        _init_and_floor_gas: &mut InitialAndFloorGas,
+    ) -> Result<(), Self::Error> {
+        let (block, tx, cfg, journal, _, _) = evm.ctx().all_mut();
+
+        if tx.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            let basefee = block.basefee() as u128;
+            let blob_price = block.blob_gasprice().unwrap_or_default();
+            let mut caller = journal.load_account_with_code_mut(tx.caller())?.data;
+
+            // Deposits have gas_price=0, so effective_balance_spending = value; net deduction is 0.
+            // Compute explicitly to match op-revm behaviour.
+            let effective_balance_spending = tx
+                .effective_balance_spending(basefee, blob_price)
+                .expect("deposit effective balance spending overflow")
+                - tx.value();
+
+            let mut new_balance = caller
+                .balance()
+                .saturating_add(U256::from(tx.mint().unwrap_or_default()))
+                .saturating_sub(effective_balance_spending);
+
+            if cfg.is_balance_check_disabled() {
+                new_balance = new_balance.max(tx.value());
+            }
+
+            caller.set_balance(new_balance);
+            if tx.kind().is_call() {
+                caller.bump_nonce();
+            }
+            return Ok(());
+        }
+
+        let mut caller_account = journal.load_account_with_code_mut(tx.caller())?.data;
+        validate_account_nonce_and_code_with_components(&caller_account.account().info, tx, cfg)?;
+        // L1 cost is always zero on RISE — no additional deduction needed.
+        let balance = calculate_caller_fee(caller_account.account().info.balance, tx, block, cfg)?;
+        caller_account.set_balance(balance);
+        if tx.kind().is_call() {
+            caller_account.bump_nonce();
+        }
+
+        Ok(())
+    }
+
+    fn last_frame_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        _original_reservoir: u64,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        let tx_gas_limit = evm.ctx().tx().gas_limit();
+
+        let instruction_result = frame_result.interpreter_result().result;
+        let gas = frame_result.gas_mut();
+        let remaining = gas.remaining();
+        let refunded = gas.refunded();
+        let reservoir = gas.reservoir();
+        let state_gas_spent = gas.state_gas_spent();
+
+        // Spend the full gas limit; reservoir and state_gas_spent are saved above and restored below.
+        *gas = Gas::new_spent_with_reservoir(tx_gas_limit, 0);
+
+        // RISE is always post-Regolith: return unused gas on success/revert for all tx types.
+        if instruction_result.is_ok() {
+            gas.erase_cost(remaining);
+            gas.record_refund(refunded);
+        } else if instruction_result.is_revert() {
+            gas.erase_cost(remaining);
+        }
+
+        // Restore fields that Gas::new_spent_with_reservoir overwrites.
+        gas.set_state_gas_spent(state_gas_spent);
+        gas.set_reservoir(reservoir);
+
+        Ok(())
+    }
+
+    fn reimburse_caller(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        // Operator fee refund — always zero on RISE.
+        reimburse_caller(evm.ctx(), frame_result.gas(), U256::ZERO).map_err(From::from)
+    }
+
+    fn refund(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        eip7702_refund: i64,
+    ) {
+        frame_result.gas_mut().record_refund(eip7702_refund);
+        // Always post-Regolith and post-London: apply EIP-3529 capped refund for all tx types.
+        let _ = evm;
+        frame_result.gas_mut().set_final_refund(true);
+    }
+
+    fn reward_beneficiary(
+        &self,
+        evm: &mut Self::Evm,
+        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+    ) -> Result<(), Self::Error> {
+        if evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            return Ok(());
+        }
+
+        // Pay the sequencer (coinbase) its share via the mainnet path.
+        self.0.reward_beneficiary(evm, frame_result)?;
+
+        let basefee = evm.ctx().block().basefee() as u128;
+        let effective_used = frame_result
+            .gas()
+            .used()
+            .saturating_sub(frame_result.gas().reservoir());
+        let base_fee_amount = U256::from(basefee.saturating_mul(effective_used as u128));
+
+        // RISE disables DA footprint and operator fees. Still touch these accounts
+        // to match revm's sequential execution state.
+        let journal = evm.ctx().journal_mut();
+        for (recipient, amount) in [
+            (L1_FEE_RECIPIENT, U256::ZERO),
+            (BASE_FEE_RECIPIENT, base_fee_amount),
+            (OPERATOR_FEE_RECIPIENT, U256::ZERO),
+        ] {
+            journal.balance_incr(recipient, amount)?;
+        }
+
+        Ok(())
+    }
+
+    fn execution_result(
+        &mut self,
+        evm: &mut Self::Evm,
+        frame_result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        result_gas: ResultGas,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        take_error::<Self::Error, _>(evm.ctx().error())?;
+
+        let exec_result = post_execution::output(evm.ctx(), frame_result, result_gas)
+            .map_haltreason(RiseHaltReason::Base);
+
+        // RISE is always post-Regolith: a halted deposit is always a fatal error.
+        if exec_result.is_halt() && evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            return Err(ERROR::from(RiseTransactionError::HaltedDepositPostRegolith));
+        }
+        evm.ctx().journal_mut().commit_tx();
+        evm.ctx().local_mut().clear();
+        evm.frame_stack().clear();
+
+        Ok(exec_result)
+    }
+
+    fn catch_error(
+        &self,
+        evm: &mut Self::Evm,
+        error: Self::Error,
+    ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
+        let is_tx_error = error.is_tx_error();
+        let mut output = Err(error);
+
+        if is_tx_error && is_deposit {
+            let caller = evm.ctx().tx().caller();
+            let mint = evm.ctx().tx().mint();
+            let gas_limit = evm.ctx().tx().gas_limit();
+            let journal = evm.ctx().journal_mut();
+
+            journal.checkpoint_revert(JournalCheckpoint::default());
+
+            let mut acc = journal.load_account_mut(caller)?;
+            acc.bump_nonce();
+            acc.incr_balance(U256::from(mint.unwrap_or_default()));
+            drop(acc); // release borrow before commit_tx
+
+            journal.commit_tx();
+
+            // RISE is always post-Regolith: failed deposits always consume their full gas.
+            output = Ok(ExecutionResult::Halt {
+                reason: RiseHaltReason::FailedDeposit,
+                gas: ResultGas::default().with_total_gas_spent(gas_limit),
+                logs: Vec::new(),
+            });
+        }
+
+        evm.ctx().local_mut().clear();
+        evm.frame_stack().clear();
+
+        output
+    }
+}

--- a/crates/pevm/src/rise_revm/handler.rs
+++ b/crates/pevm/src/rise_revm/handler.rs
@@ -1,5 +1,5 @@
 use crate::rise_revm::{
-    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, RiseHaltReason,
+    BASE_FEE_RECIPIENT, RiseHaltReason,
     evm::RiseEvm,
     transaction::{DEPOSIT_TRANSACTION_TYPE, RiseTransactionError},
 };
@@ -165,16 +165,9 @@ impl<DB: Database> Handler for RiseHandler<DB> {
             .saturating_sub(frame_result.gas().reservoir());
         let base_fee_amount = U256::from(basefee.saturating_mul(effective_used as u128));
 
-        // RISE disables DA footprint and operator fees. Still touch these accounts
-        // to match revm's sequential execution state.
-        let journal = evm.ctx().journal_mut();
-        for (recipient, amount) in [
-            (L1_FEE_RECIPIENT, U256::ZERO),
-            (BASE_FEE_RECIPIENT, base_fee_amount),
-            (OPERATOR_FEE_RECIPIENT, U256::ZERO),
-        ] {
-            journal.balance_incr(recipient, amount)?;
-        }
+        evm.ctx()
+            .journal_mut()
+            .balance_incr(BASE_FEE_RECIPIENT, base_fee_amount)?;
 
         Ok(())
     }
@@ -190,7 +183,7 @@ impl<DB: Database> Handler for RiseHandler<DB> {
         let exec_result = post_execution::output(evm.ctx(), frame_result, result_gas)
             .map_haltreason(RiseHaltReason::Base);
 
-        // RISE is always post-Regolith: a halted deposit is always a fatal error.
+        // RISE: halted deposit is always a fatal error.
         if exec_result.is_halt() && evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE {
             return Err(RiseTransactionError::HaltedDepositPostRegolith.into());
         }
@@ -206,6 +199,10 @@ impl<DB: Database> Handler for RiseHandler<DB> {
         evm: &mut Self::Evm,
         error: Self::Error,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
+        // Post-Regolith: a deposit that fails *validation* (tx error) must not propagate the
+        // error. Instead, revert all execution side-effects, apply only the mint and nonce
+        // increment, then return a FailedDeposit halt. DB errors and non-deposit tx errors
+        // propagate normally.
         let output = if matches!(error, EVMError::Transaction(_))
             && evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE
         {
@@ -222,7 +219,6 @@ impl<DB: Database> Handler for RiseHandler<DB> {
 
             evm.ctx().journal_mut().commit_tx();
 
-            // RISE is always post-Regolith: failed deposits always consume their full gas.
             Ok(ExecutionResult::Halt {
                 reason: RiseHaltReason::FailedDeposit,
                 gas: ResultGas::default().with_total_gas_spent(evm.ctx().tx().gas_limit()),

--- a/crates/pevm/src/rise_revm/handler.rs
+++ b/crates/pevm/src/rise_revm/handler.rs
@@ -1,21 +1,21 @@
 use crate::rise_revm::{
-    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, OpContextTr, RiseHaltReason,
+    BASE_FEE_RECIPIENT, L1_FEE_RECIPIENT, OPERATOR_FEE_RECIPIENT, RiseHaltReason,
+    evm::RiseEvm,
     transaction::{DEPOSIT_TRANSACTION_TYPE, RiseTransactionError},
 };
 use revm::{
+    Database,
     context::{
         LocalContextTr,
         journaled_state::{JournalCheckpoint, account::JournaledAccountTr},
     },
     context_interface::{
-        Block, Cfg, ContextTr, JournalTr, Transaction,
+        Block, ContextTr, JournalTr, Transaction,
         context::take_error,
-        result::{EVMError, ExecutionResult, FromStringError, ResultGas},
+        result::{EVMError, ExecutionResult, ResultGas},
     },
     handler::{
-        EthFrame, EvmTr, Handler, MainnetHandler,
-        evm::FrameTr,
-        handler::EvmTrError,
+        EthFrame, EvmTr, FrameResult, Handler, MainnetHandler,
         post_execution::{self, reimburse_caller},
         pre_execution::{calculate_caller_fee, validate_account_nonce_and_code_with_components},
     },
@@ -24,35 +24,24 @@ use revm::{
 };
 use std::vec::Vec;
 
-/// Helper to identify transaction-level errors (used in `catch_error`).
-pub(crate) trait IsTxError {
-    fn is_tx_error(&self) -> bool;
-}
-
-impl<DB, TX> IsTxError for EVMError<DB, TX> {
-    fn is_tx_error(&self) -> bool {
-        matches!(self, Self::Transaction(_))
-    }
-}
+type RiseHandlerError<DB> = EVMError<<DB as Database>::Error, RiseTransactionError>;
 
 /// Wraps [`MainnetHandler`] and overrides the methods that differ for OP Stack chains:
 /// deposit transaction handling, gas accounting, and fee distribution.
 #[derive(Debug)]
-pub(crate) struct OpHandler<EVM, ERROR>(MainnetHandler<EVM, ERROR, EthFrame<EthInterpreter>>);
+pub(crate) struct RiseHandler<DB: Database>(
+    MainnetHandler<RiseEvm<DB>, RiseHandlerError<DB>, EthFrame<EthInterpreter>>,
+);
 
-impl<EVM, ERROR> Default for OpHandler<EVM, ERROR> {
+impl<DB: Database> Default for RiseHandler<DB> {
     fn default() -> Self {
         Self(MainnetHandler::default())
     }
 }
 
-impl<EVM, ERROR> Handler for OpHandler<EVM, ERROR>
-where
-    EVM: EvmTr<Context: OpContextTr, Frame = EthFrame<EthInterpreter>>,
-    ERROR: EvmTrError<EVM> + From<RiseTransactionError> + FromStringError + IsTxError,
-{
-    type Evm = EVM;
-    type Error = ERROR;
+impl<DB: Database> Handler for RiseHandler<DB> {
+    type Evm = RiseEvm<DB>;
+    type Error = RiseHandlerError<DB>;
     type HaltReason = RiseHaltReason;
 
     fn validate_env(&self, evm: &mut Self::Evm) -> Result<(), Self::Error> {
@@ -78,45 +67,35 @@ where
     fn validate_against_state_and_deduct_caller(
         &self,
         evm: &mut Self::Evm,
-        _init_and_floor_gas: &mut InitialAndFloorGas,
+        _: &mut InitialAndFloorGas,
     ) -> Result<(), Self::Error> {
         let (block, tx, cfg, journal, _, _) = evm.ctx().all_mut();
 
+        let mut caller = journal.load_account_with_code_mut(tx.caller())?.data;
+
         if tx.tx_type() == DEPOSIT_TRANSACTION_TYPE {
-            let basefee = block.basefee() as u128;
-            let blob_price = block.blob_gasprice().unwrap_or_default();
-            let mut caller = journal.load_account_with_code_mut(tx.caller())?.data;
-
-            // Deposits have gas_price=0, so effective_balance_spending = value; net deduction is 0.
-            // Compute explicitly to match op-revm behaviour.
-            let effective_balance_spending = tx
-                .effective_balance_spending(basefee, blob_price)
-                .expect("deposit effective balance spending overflow")
-                - tx.value();
-
-            let mut new_balance = caller
+            // Deposit balance update: new_balance = old_balance + mint.
+            // The general formula is: new_balance = old_balance + mint - effective_balance_spending + value,
+            // where effective_balance_spending = gas_limit * gas_price + blob_cost + value.
+            // Deposits enforce gas_price=0 and carry no blob hashes, so effective_balance_spending = value,
+            // and the net deduction is always zero — leaving only the mint credit.
+            let new_balance = caller
                 .balance()
-                .saturating_add(U256::from(tx.mint().unwrap_or_default()))
-                .saturating_sub(effective_balance_spending);
-
-            if cfg.is_balance_check_disabled() {
-                new_balance = new_balance.max(tx.value());
-            }
-
+                .saturating_add(U256::from(tx.mint().unwrap_or_default()));
             caller.set_balance(new_balance);
-            if tx.kind().is_call() {
-                caller.bump_nonce();
-            }
-            return Ok(());
+        } else {
+            validate_account_nonce_and_code_with_components(&caller.account().info, tx, cfg)?;
+            // L1 cost is always zero on RISE — no additional deduction needed.
+            caller.set_balance(calculate_caller_fee(
+                caller.account().info.balance,
+                tx,
+                block,
+                cfg,
+            )?);
         }
 
-        let mut caller_account = journal.load_account_with_code_mut(tx.caller())?.data;
-        validate_account_nonce_and_code_with_components(&caller_account.account().info, tx, cfg)?;
-        // L1 cost is always zero on RISE — no additional deduction needed.
-        let balance = calculate_caller_fee(caller_account.account().info.balance, tx, block, cfg)?;
-        caller_account.set_balance(balance);
         if tx.kind().is_call() {
-            caller_account.bump_nonce();
+            caller.bump_nonce();
         }
 
         Ok(())
@@ -125,20 +104,18 @@ where
     fn last_frame_result(
         &mut self,
         evm: &mut Self::Evm,
-        _original_reservoir: u64,
-        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        _: u64,
+        frame_result: &mut FrameResult,
     ) -> Result<(), Self::Error> {
-        let tx_gas_limit = evm.ctx().tx().gas_limit();
-
         let instruction_result = frame_result.interpreter_result().result;
         let gas = frame_result.gas_mut();
+
+        // Save fields that Gas::new_spent_with_reservoir overwrites, then reset to fully-spent.
         let remaining = gas.remaining();
         let refunded = gas.refunded();
         let reservoir = gas.reservoir();
         let state_gas_spent = gas.state_gas_spent();
-
-        // Spend the full gas limit; reservoir and state_gas_spent are saved above and restored below.
-        *gas = Gas::new_spent_with_reservoir(tx_gas_limit, 0);
+        *gas = Gas::new_spent_with_reservoir(evm.ctx().tx().gas_limit(), 0);
 
         // RISE is always post-Regolith: return unused gas on success/revert for all tx types.
         if instruction_result.is_ok() {
@@ -148,7 +125,6 @@ where
             gas.erase_cost(remaining);
         }
 
-        // Restore fields that Gas::new_spent_with_reservoir overwrites.
         gas.set_state_gas_spent(state_gas_spent);
         gas.set_reservoir(reservoir);
 
@@ -158,28 +134,22 @@ where
     fn reimburse_caller(
         &self,
         evm: &mut Self::Evm,
-        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        frame_result: &mut FrameResult,
     ) -> Result<(), Self::Error> {
         // Operator fee refund — always zero on RISE.
         reimburse_caller(evm.ctx(), frame_result.gas(), U256::ZERO).map_err(From::from)
     }
 
-    fn refund(
-        &self,
-        evm: &mut Self::Evm,
-        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
-        eip7702_refund: i64,
-    ) {
+    fn refund(&self, _: &mut Self::Evm, frame_result: &mut FrameResult, eip7702_refund: i64) {
         frame_result.gas_mut().record_refund(eip7702_refund);
         // Always post-Regolith and post-London: apply EIP-3529 capped refund for all tx types.
-        let _ = evm;
         frame_result.gas_mut().set_final_refund(true);
     }
 
     fn reward_beneficiary(
         &self,
         evm: &mut Self::Evm,
-        frame_result: &mut <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        frame_result: &mut FrameResult,
     ) -> Result<(), Self::Error> {
         if evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE {
             return Ok(());
@@ -212,7 +182,7 @@ where
     fn execution_result(
         &mut self,
         evm: &mut Self::Evm,
-        frame_result: <<Self::Evm as EvmTr>::Frame as FrameTr>::FrameResult,
+        frame_result: FrameResult,
         result_gas: ResultGas,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
         take_error::<Self::Error, _>(evm.ctx().error())?;
@@ -222,7 +192,7 @@ where
 
         // RISE is always post-Regolith: a halted deposit is always a fatal error.
         if exec_result.is_halt() && evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE {
-            return Err(ERROR::from(RiseTransactionError::HaltedDepositPostRegolith));
+            return Err(RiseTransactionError::HaltedDepositPostRegolith.into());
         }
         evm.ctx().journal_mut().commit_tx();
         evm.ctx().local_mut().clear();
@@ -236,32 +206,31 @@ where
         evm: &mut Self::Evm,
         error: Self::Error,
     ) -> Result<ExecutionResult<Self::HaltReason>, Self::Error> {
-        let is_deposit = evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE;
-        let is_tx_error = error.is_tx_error();
-        let mut output = Err(error);
-
-        if is_tx_error && is_deposit {
+        let output = if matches!(error, EVMError::Transaction(_))
+            && evm.ctx().tx().tx_type() == DEPOSIT_TRANSACTION_TYPE
+        {
             let caller = evm.ctx().tx().caller();
             let mint = evm.ctx().tx().mint();
-            let gas_limit = evm.ctx().tx().gas_limit();
-            let journal = evm.ctx().journal_mut();
 
-            journal.checkpoint_revert(JournalCheckpoint::default());
+            evm.ctx()
+                .journal_mut()
+                .checkpoint_revert(JournalCheckpoint::default());
 
-            let mut acc = journal.load_account_mut(caller)?;
+            let mut acc = evm.ctx().journal_mut().load_account_mut(caller)?;
             acc.bump_nonce();
             acc.incr_balance(U256::from(mint.unwrap_or_default()));
-            drop(acc); // release borrow before commit_tx
 
-            journal.commit_tx();
+            evm.ctx().journal_mut().commit_tx();
 
             // RISE is always post-Regolith: failed deposits always consume their full gas.
-            output = Ok(ExecutionResult::Halt {
+            Ok(ExecutionResult::Halt {
                 reason: RiseHaltReason::FailedDeposit,
-                gas: ResultGas::default().with_total_gas_spent(gas_limit),
+                gas: ResultGas::default().with_total_gas_spent(evm.ctx().tx().gas_limit()),
                 logs: Vec::new(),
-            });
-        }
+            })
+        } else {
+            Err(error)
+        };
 
         evm.ctx().local_mut().clear();
         evm.frame_stack().clear();

--- a/crates/pevm/src/rise_revm/mod.rs
+++ b/crates/pevm/src/rise_revm/mod.rs
@@ -15,9 +15,8 @@ pub(crate) use transaction::{RiseTransaction, RiseTransactionError};
 use revm::{
     Context, Journal,
     context::{BlockEnv, CfgEnv, TxEnv},
-    context_interface::{Cfg, ContextTr, JournalTr, result::HaltReason},
+    context_interface::result::HaltReason,
     primitives::{Address, address, hardfork::SpecId},
-    state::EvmState,
 };
 
 pub(crate) const L1_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001A");
@@ -27,29 +26,8 @@ pub(crate) const BASE_FEE_RECIPIENT: Address =
     address!("0x4200000000000000000000000000000000000019");
 
 /// The default OP context type: mainnet context + [`RiseTransaction`] + unit chain (no L1 fees).
-pub(crate) type OpContext<DB> =
+pub(crate) type RiseContext<DB> =
     Context<BlockEnv, RiseTransaction<TxEnv>, CfgEnv<SpecId>, DB, Journal<DB>, ()>;
-
-/// Marker trait for OP-capable EVM contexts.
-pub(crate) trait OpContextTr:
-    ContextTr<
-        Journal: JournalTr<State = EvmState>,
-        Tx = RiseTransaction<TxEnv>,
-        Cfg: Cfg<Spec = SpecId>,
-        Chain = (),
-    >
-{
-}
-
-impl<T> OpContextTr for T where
-    T: ContextTr<
-            Journal: JournalTr<State = EvmState>,
-            Tx = RiseTransaction<TxEnv>,
-            Cfg: Cfg<Spec = SpecId>,
-            Chain = (),
-        >
-{
-}
 
 /// Halt reason for RISE/OP-Stack execution.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/pevm/src/rise_revm/mod.rs
+++ b/crates/pevm/src/rise_revm/mod.rs
@@ -1,0 +1,65 @@
+//! Vendored OP-Stack EVM types, stripped down for RISE.
+//!
+//! The external `op-revm` crate pins `revm = "^38"` which is incompatible with our revm 39
+//! upgrade.  We vendor only what RISE needs, updated for the revm 39 API and simplified to
+//! remove all L1/DA/operator fee arithmetic (RISE zeroes all of these).
+
+pub(crate) mod evm;
+pub(crate) mod handler;
+pub(crate) mod precompiles;
+pub(crate) mod transaction;
+
+pub(crate) use evm::RiseEvm;
+pub(crate) use transaction::{RiseTransaction, RiseTransactionError};
+
+use revm::{
+    Context, Journal,
+    context::{BlockEnv, CfgEnv, TxEnv},
+    context_interface::{Cfg, ContextTr, JournalTr, result::HaltReason},
+    primitives::{Address, address, hardfork::SpecId},
+    state::EvmState,
+};
+
+pub(crate) const L1_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001A");
+pub(crate) const OPERATOR_FEE_RECIPIENT: Address =
+    address!("0x420000000000000000000000000000000000001B");
+pub(crate) const BASE_FEE_RECIPIENT: Address =
+    address!("0x4200000000000000000000000000000000000019");
+
+/// The default OP context type: mainnet context + [`RiseTransaction`] + unit chain (no L1 fees).
+pub(crate) type OpContext<DB> =
+    Context<BlockEnv, RiseTransaction<TxEnv>, CfgEnv<SpecId>, DB, Journal<DB>, ()>;
+
+/// Marker trait for OP-capable EVM contexts.
+pub(crate) trait OpContextTr:
+    ContextTr<
+        Journal: JournalTr<State = EvmState>,
+        Tx = RiseTransaction<TxEnv>,
+        Cfg: Cfg<Spec = SpecId>,
+        Chain = (),
+    >
+{
+}
+
+impl<T> OpContextTr for T where
+    T: ContextTr<
+            Journal: JournalTr<State = EvmState>,
+            Tx = RiseTransaction<TxEnv>,
+            Cfg: Cfg<Spec = SpecId>,
+            Chain = (),
+        >
+{
+}
+
+/// Halt reason for RISE/OP-Stack execution.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RiseHaltReason {
+    Base(HaltReason),
+    FailedDeposit,
+}
+
+impl From<HaltReason> for RiseHaltReason {
+    fn from(value: HaltReason) -> Self {
+        Self::Base(value)
+    }
+}

--- a/crates/pevm/src/rise_revm/mod.rs
+++ b/crates/pevm/src/rise_revm/mod.rs
@@ -14,20 +14,17 @@ pub(crate) use transaction::{RiseTransaction, RiseTransactionError};
 
 use revm::{
     Context, Journal,
-    context::{BlockEnv, CfgEnv, TxEnv},
+    context::{BlockEnv, CfgEnv},
     context_interface::result::HaltReason,
     primitives::{Address, address, hardfork::SpecId},
 };
 
-pub(crate) const L1_FEE_RECIPIENT: Address = address!("0x420000000000000000000000000000000000001A");
-pub(crate) const OPERATOR_FEE_RECIPIENT: Address =
-    address!("0x420000000000000000000000000000000000001B");
 pub(crate) const BASE_FEE_RECIPIENT: Address =
     address!("0x4200000000000000000000000000000000000019");
 
 /// The default OP context type: mainnet context + [`RiseTransaction`] + unit chain (no L1 fees).
 pub(crate) type RiseContext<DB> =
-    Context<BlockEnv, RiseTransaction<TxEnv>, CfgEnv<SpecId>, DB, Journal<DB>, ()>;
+    Context<BlockEnv, RiseTransaction, CfgEnv<SpecId>, DB, Journal<DB>, ()>;
 
 /// Halt reason for RISE/OP-Stack execution.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/pevm/src/rise_revm/precompiles.rs
+++ b/crates/pevm/src/rise_revm/precompiles.rs
@@ -1,0 +1,167 @@
+use revm::{
+    context::Cfg,
+    context_interface::ContextTr,
+    handler::{EthPrecompiles, PrecompileProvider},
+    interpreter::{CallInputs, InterpreterResult},
+    precompile::{
+        self, EthPrecompileResult, Precompile, PrecompileHalt, PrecompileId, Precompiles, bn254,
+        eth_precompile_fn, secp256r1,
+    },
+    primitives::{AddressSet, OnceLock, hardfork::SpecId},
+};
+use std::string::String;
+
+/// Precompile provider for RISE — always uses the Jovian precompile set.
+#[derive(Debug, Clone)]
+pub struct OpPrecompiles(EthPrecompiles);
+
+impl Default for OpPrecompiles {
+    fn default() -> Self {
+        Self(EthPrecompiles {
+            precompiles: rise_precompiles(),
+            spec: SpecId::default(),
+        })
+    }
+}
+
+impl<CTX> PrecompileProvider<CTX> for OpPrecompiles
+where
+    CTX: ContextTr<Cfg: Cfg<Spec = SpecId>>,
+{
+    type Output = InterpreterResult;
+
+    #[inline]
+    fn set_spec(&mut self, _: SpecId) -> bool {
+        false // RISE always uses Jovian precompiles
+    }
+
+    #[inline]
+    fn run(
+        &mut self,
+        context: &mut CTX,
+        inputs: &CallInputs,
+    ) -> Result<Option<Self::Output>, String> {
+        self.0.run(context, inputs)
+    }
+
+    #[inline]
+    fn warm_addresses(&self) -> &AddressSet {
+        self.0.warm_addresses()
+    }
+
+    #[inline]
+    fn contains(&self, address: &revm::primitives::Address) -> bool {
+        self.0.contains(address)
+    }
+}
+
+/// Builds the Jovian precompile set used by RISE.
+///
+/// Starts from Cancun, adds secp256r1 and BLS12-381 (Isthmus/Granite), then replaces
+/// bn254 pairing and BLS12-381 MSM/pairing with Jovian input-size-limited versions.
+fn rise_precompiles() -> &'static Precompiles {
+    static INSTANCE: OnceLock<Precompiles> = OnceLock::new();
+    INSTANCE.get_or_init(|| {
+        let mut p = Precompiles::cancun().clone();
+        p.extend([secp256r1::P256VERIFY]);
+        p.extend(precompile::bls12_381::precompiles());
+        // Jovian: replace bn254 pair and BLS MSM/pairing with tighter input-size limits.
+        p.extend([bn254_pair::JOVIAN]);
+        p.extend([
+            bls12_381::JOVIAN_G1_MSM,
+            bls12_381::JOVIAN_G2_MSM,
+            bls12_381::JOVIAN_PAIRING,
+        ]);
+        p
+    })
+}
+
+/// Bn254 pairing precompile with Jovian input size limit.
+mod bn254_pair {
+    use super::*;
+
+    const JOVIAN_MAX: usize = 81_984;
+    pub(super) const JOVIAN: Precompile =
+        Precompile::new(PrecompileId::Bn254Pairing, bn254::pair::ADDRESS, jovian_fn);
+
+    fn run_jovian(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        if input.len() > JOVIAN_MAX {
+            return Err(PrecompileHalt::Bn254PairLength);
+        }
+        bn254::run_pair(
+            input,
+            bn254::pair::ISTANBUL_PAIR_PER_POINT,
+            bn254::pair::ISTANBUL_PAIR_BASE,
+            gas_limit,
+        )
+    }
+    eth_precompile_fn!(jovian_fn, run_jovian);
+}
+
+/// BLS12-381 precompiles with Jovian input size limits.
+mod bls12_381 {
+    use super::*;
+    use revm::precompile::bls12_381_const::{G1_MSM_ADDRESS, G2_MSM_ADDRESS, PAIRING_ADDRESS};
+
+    const JOVIAN_G1_MSM_MAX: usize = 288_960;
+    const JOVIAN_G2_MSM_MAX: usize = 278_784;
+    const JOVIAN_PAIRING_MAX: usize = 156_672;
+
+    pub(super) const JOVIAN_G1_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G1Msm, G1_MSM_ADDRESS, jovian_g1_msm_fn);
+    pub(super) const JOVIAN_G2_MSM: Precompile =
+        Precompile::new(PrecompileId::Bls12G2Msm, G2_MSM_ADDRESS, jovian_g2_msm_fn);
+    pub(super) const JOVIAN_PAIRING: Precompile = Precompile::new(
+        PrecompileId::Bls12Pairing,
+        PAIRING_ADDRESS,
+        jovian_pairing_fn,
+    );
+
+    #[inline(always)]
+    fn run_with_limit(
+        input: &[u8],
+        gas_limit: u64,
+        max: usize,
+        err: &'static str,
+        inner: fn(&[u8], u64) -> EthPrecompileResult,
+    ) -> EthPrecompileResult {
+        if input.len() > max {
+            Err(PrecompileHalt::Other(err.into()))
+        } else {
+            inner(input, gas_limit)
+        }
+    }
+
+    fn run_jovian_g1_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        run_with_limit(
+            input,
+            gas_limit,
+            JOVIAN_G1_MSM_MAX,
+            "G1MSM input exceeds Jovian limit",
+            precompile::bls12_381::g1_msm::g1_msm,
+        )
+    }
+    eth_precompile_fn!(jovian_g1_msm_fn, run_jovian_g1_msm);
+
+    fn run_jovian_g2_msm(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        run_with_limit(
+            input,
+            gas_limit,
+            JOVIAN_G2_MSM_MAX,
+            "G2MSM input exceeds Jovian limit",
+            precompile::bls12_381::g2_msm::g2_msm,
+        )
+    }
+    eth_precompile_fn!(jovian_g2_msm_fn, run_jovian_g2_msm);
+
+    fn run_jovian_pairing(input: &[u8], gas_limit: u64) -> EthPrecompileResult {
+        run_with_limit(
+            input,
+            gas_limit,
+            JOVIAN_PAIRING_MAX,
+            "Pairing input exceeds Jovian limit",
+            precompile::bls12_381::pairing::pairing,
+        )
+    }
+    eth_precompile_fn!(jovian_pairing_fn, run_jovian_pairing);
+}

--- a/crates/pevm/src/rise_revm/precompiles.rs
+++ b/crates/pevm/src/rise_revm/precompiles.rs
@@ -13,9 +13,9 @@ use std::string::String;
 
 /// Precompile provider for RISE — always uses the Jovian precompile set.
 #[derive(Debug, Clone)]
-pub struct OpPrecompiles(EthPrecompiles);
+pub struct RisePrecompiles(EthPrecompiles);
 
-impl Default for OpPrecompiles {
+impl Default for RisePrecompiles {
     fn default() -> Self {
         Self(EthPrecompiles {
             precompiles: rise_precompiles(),
@@ -24,7 +24,7 @@ impl Default for OpPrecompiles {
     }
 }
 
-impl<CTX> PrecompileProvider<CTX> for OpPrecompiles
+impl<CTX> PrecompileProvider<CTX> for RisePrecompiles
 where
     CTX: ContextTr<Cfg: Cfg<Spec = SpecId>>,
 {

--- a/crates/pevm/src/rise_revm/precompiles.rs
+++ b/crates/pevm/src/rise_revm/precompiles.rs
@@ -1,6 +1,5 @@
 use revm::{
-    context::Cfg,
-    context_interface::ContextTr,
+    Database,
     handler::{EthPrecompiles, PrecompileProvider},
     interpreter::{CallInputs, InterpreterResult},
     precompile::{
@@ -10,6 +9,8 @@ use revm::{
     primitives::{AddressSet, OnceLock, hardfork::SpecId},
 };
 use std::string::String;
+
+use super::RiseContext;
 
 /// Precompile provider for RISE — always uses the Jovian precompile set.
 #[derive(Debug, Clone)]
@@ -24,10 +25,7 @@ impl Default for RisePrecompiles {
     }
 }
 
-impl<CTX> PrecompileProvider<CTX> for RisePrecompiles
-where
-    CTX: ContextTr<Cfg: Cfg<Spec = SpecId>>,
-{
+impl<DB: Database> PrecompileProvider<RiseContext<DB>> for RisePrecompiles {
     type Output = InterpreterResult;
 
     #[inline]
@@ -38,7 +36,7 @@ where
     #[inline]
     fn run(
         &mut self,
-        context: &mut CTX,
+        context: &mut RiseContext<DB>,
         inputs: &CallInputs,
     ) -> Result<Option<Self::Output>, String> {
         self.0.run(context, inputs)

--- a/crates/pevm/src/rise_revm/transaction.rs
+++ b/crates/pevm/src/rise_revm/transaction.rs
@@ -1,5 +1,3 @@
-use core::fmt;
-
 use revm::{
     context::{
         TxEnv,
@@ -20,16 +18,6 @@ pub struct DepositTransactionParts {
     pub source_hash: B256,
     pub mint: Option<u128>,
     pub is_system_transaction: bool,
-}
-
-impl DepositTransactionParts {
-    pub const fn new(source_hash: B256, mint: Option<u128>, is_system_transaction: bool) -> Self {
-        Self {
-            source_hash,
-            mint,
-            is_system_transaction,
-        }
-    }
 }
 
 /// Optimism transaction: wraps [`TxEnv`] with deposit-specific fields.
@@ -156,34 +144,21 @@ impl Transaction for RiseTransaction {
 }
 
 /// Optimism transaction validation error.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, thiserror::Error)]
 pub enum RiseTransactionError {
-    Base(revm::context::result::InvalidTransaction),
+    #[error(transparent)]
+    Base(InvalidTransaction),
+    #[error("deposit system transactions post regolith hardfork are not supported")]
     DepositSystemTxPostRegolith,
+    #[error(
+        "deposit transaction halted post-regolith; error will be bubbled up to main return handler"
+    )]
     HaltedDepositPostRegolith,
+    #[error("missing enveloped transaction bytes for non-deposit transaction")]
     MissingEnvelopedTx,
 }
 
 impl TransactionError for RiseTransactionError {}
-
-impl fmt::Display for RiseTransactionError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Base(e) => e.fmt(f),
-            Self::DepositSystemTxPostRegolith => f.write_str(
-                "deposit system transactions post regolith hardfork are not supported",
-            ),
-            Self::HaltedDepositPostRegolith => f.write_str(
-                "deposit transaction halted post-regolith; error will be bubbled up to main return handler",
-            ),
-            Self::MissingEnvelopedTx => f.write_str(
-                "missing enveloped transaction bytes for non-deposit transaction",
-            ),
-        }
-    }
-}
-
-impl core::error::Error for RiseTransactionError {}
 
 impl From<InvalidTransaction> for RiseTransactionError {
     fn from(value: InvalidTransaction) -> Self {

--- a/crates/pevm/src/rise_revm/transaction.rs
+++ b/crates/pevm/src/rise_revm/transaction.rs
@@ -1,0 +1,216 @@
+use revm::{
+    context::TxEnv,
+    context_interface::transaction::Transaction,
+    handler::SystemCallTx,
+    primitives::{Address, B256, Bytes, TxKind, U256},
+};
+
+/// Deposit transaction type byte.
+pub(crate) const DEPOSIT_TRANSACTION_TYPE: u8 = 0x7E;
+
+/// Parts of a deposit transaction not present in normal transactions.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct DepositTransactionParts {
+    pub source_hash: B256,
+    pub mint: Option<u128>,
+    pub is_system_transaction: bool,
+}
+
+impl DepositTransactionParts {
+    pub const fn new(source_hash: B256, mint: Option<u128>, is_system_transaction: bool) -> Self {
+        Self {
+            source_hash,
+            mint,
+            is_system_transaction,
+        }
+    }
+}
+
+/// Optimism transaction: wraps a base transaction with deposit-specific fields.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RiseTransaction<T: Transaction> {
+    pub base: T,
+    /// Enveloped EIP-2718 bytes, required for L1 cost computation on non-deposits.
+    pub enveloped_tx: Option<Bytes>,
+    pub deposit: DepositTransactionParts,
+}
+
+impl<T: Transaction> RiseTransaction<T> {
+    pub fn new(base: T) -> Self {
+        Self {
+            base,
+            enveloped_tx: None,
+            deposit: DepositTransactionParts::default(),
+        }
+    }
+
+    pub const fn enveloped_tx(&self) -> Option<&Bytes> {
+        self.enveloped_tx.as_ref()
+    }
+
+    pub const fn mint(&self) -> Option<u128> {
+        self.deposit.mint
+    }
+
+    pub const fn is_system_transaction(&self) -> bool {
+        self.deposit.is_system_transaction
+    }
+
+    pub fn is_deposit(&self) -> bool {
+        self.tx_type() == DEPOSIT_TRANSACTION_TYPE
+    }
+}
+
+impl<T: Transaction> AsRef<T> for RiseTransaction<T> {
+    fn as_ref(&self) -> &T {
+        &self.base
+    }
+}
+
+impl Default for RiseTransaction<TxEnv> {
+    fn default() -> Self {
+        Self {
+            base: TxEnv::default(),
+            // Dummy non-empty bytes so validate_env passes the MissingEnvelopedTx check
+            // for non-deposit transactions when the EVM is first constructed.
+            enveloped_tx: Some(vec![0x00].into()),
+            deposit: DepositTransactionParts::default(),
+        }
+    }
+}
+
+impl<TX: Transaction + SystemCallTx> SystemCallTx for RiseTransaction<TX> {
+    fn new_system_tx_with_caller(
+        caller: Address,
+        system_contract_address: Address,
+        data: Bytes,
+    ) -> Self {
+        let mut tx = Self::new(TX::new_system_tx_with_caller(
+            caller,
+            system_contract_address,
+            data,
+        ));
+        tx.enveloped_tx = Some(Bytes::default());
+        tx
+    }
+}
+
+impl<T: Transaction> Transaction for RiseTransaction<T> {
+    type AccessListItem<'a>
+        = T::AccessListItem<'a>
+    where
+        T: 'a;
+    type Authorization<'a>
+        = T::Authorization<'a>
+    where
+        T: 'a;
+
+    fn tx_type(&self) -> u8 {
+        // Deposits are identified by a non-zero source_hash.
+        if self.deposit.source_hash == B256::ZERO {
+            self.base.tx_type()
+        } else {
+            DEPOSIT_TRANSACTION_TYPE
+        }
+    }
+
+    fn caller(&self) -> Address {
+        self.base.caller()
+    }
+    fn gas_limit(&self) -> u64 {
+        self.base.gas_limit()
+    }
+    fn value(&self) -> U256 {
+        self.base.value()
+    }
+    fn input(&self) -> &Bytes {
+        self.base.input()
+    }
+    fn nonce(&self) -> u64 {
+        self.base.nonce()
+    }
+    fn kind(&self) -> TxKind {
+        self.base.kind()
+    }
+    fn chain_id(&self) -> Option<u64> {
+        self.base.chain_id()
+    }
+    fn max_priority_fee_per_gas(&self) -> Option<u128> {
+        self.base.max_priority_fee_per_gas()
+    }
+    fn max_fee_per_gas(&self) -> u128 {
+        self.base.max_fee_per_gas()
+    }
+    fn gas_price(&self) -> u128 {
+        self.base.gas_price()
+    }
+    fn blob_versioned_hashes(&self) -> &[B256] {
+        self.base.blob_versioned_hashes()
+    }
+    fn max_fee_per_blob_gas(&self) -> u128 {
+        self.base.max_fee_per_blob_gas()
+    }
+    fn authorization_list_len(&self) -> usize {
+        self.base.authorization_list_len()
+    }
+
+    fn access_list(&self) -> Option<impl Iterator<Item = Self::AccessListItem<'_>>> {
+        self.base.access_list()
+    }
+
+    fn effective_gas_price(&self, base_fee: u128) -> u128 {
+        // Deposits use gas_price directly (always 0).
+        if self.tx_type() == DEPOSIT_TRANSACTION_TYPE {
+            return self.gas_price();
+        }
+        self.base.effective_gas_price(base_fee)
+    }
+
+    fn authorization_list(&self) -> impl Iterator<Item = Self::Authorization<'_>> {
+        self.base.authorization_list()
+    }
+}
+
+/// Optimism transaction validation error.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum RiseTransactionError {
+    Base(revm::context::result::InvalidTransaction),
+    DepositSystemTxPostRegolith,
+    HaltedDepositPostRegolith,
+    MissingEnvelopedTx,
+}
+
+impl revm::context_interface::transaction::TransactionError for RiseTransactionError {}
+
+impl core::fmt::Display for RiseTransactionError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Base(e) => e.fmt(f),
+            Self::DepositSystemTxPostRegolith => f.write_str(
+                "deposit system transactions post regolith hardfork are not supported",
+            ),
+            Self::HaltedDepositPostRegolith => f.write_str(
+                "deposit transaction halted post-regolith; error will be bubbled up to main return handler",
+            ),
+            Self::MissingEnvelopedTx => f.write_str(
+                "missing enveloped transaction bytes for non-deposit transaction",
+            ),
+        }
+    }
+}
+
+impl core::error::Error for RiseTransactionError {}
+
+impl From<revm::context::result::InvalidTransaction> for RiseTransactionError {
+    fn from(value: revm::context::result::InvalidTransaction) -> Self {
+        Self::Base(value)
+    }
+}
+
+impl<DBError> From<RiseTransactionError>
+    for revm::context_interface::result::EVMError<DBError, RiseTransactionError>
+{
+    fn from(value: RiseTransactionError) -> Self {
+        Self::Transaction(value)
+    }
+}

--- a/crates/pevm/src/rise_revm/transaction.rs
+++ b/crates/pevm/src/rise_revm/transaction.rs
@@ -1,5 +1,11 @@
+use core::fmt;
+
 use revm::{
-    context::TxEnv,
+    context::{
+        TxEnv,
+        result::{EVMError, InvalidTransaction},
+        transaction::TransactionError,
+    },
     context_interface::transaction::Transaction,
     handler::SystemCallTx,
     primitives::{Address, B256, Bytes, TxKind, U256},
@@ -26,24 +32,16 @@ impl DepositTransactionParts {
     }
 }
 
-/// Optimism transaction: wraps a base transaction with deposit-specific fields.
+/// Optimism transaction: wraps [`TxEnv`] with deposit-specific fields.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct RiseTransaction<T: Transaction> {
-    pub base: T,
+pub struct RiseTransaction {
+    pub base: TxEnv,
     /// Enveloped EIP-2718 bytes, required for L1 cost computation on non-deposits.
     pub enveloped_tx: Option<Bytes>,
     pub deposit: DepositTransactionParts,
 }
 
-impl<T: Transaction> RiseTransaction<T> {
-    pub fn new(base: T) -> Self {
-        Self {
-            base,
-            enveloped_tx: None,
-            deposit: DepositTransactionParts::default(),
-        }
-    }
-
+impl RiseTransaction {
     pub const fn enveloped_tx(&self) -> Option<&Bytes> {
         self.enveloped_tx.as_ref()
     }
@@ -61,13 +59,7 @@ impl<T: Transaction> RiseTransaction<T> {
     }
 }
 
-impl<T: Transaction> AsRef<T> for RiseTransaction<T> {
-    fn as_ref(&self) -> &T {
-        &self.base
-    }
-}
-
-impl Default for RiseTransaction<TxEnv> {
+impl Default for RiseTransaction {
     fn default() -> Self {
         Self {
             base: TxEnv::default(),
@@ -79,31 +71,23 @@ impl Default for RiseTransaction<TxEnv> {
     }
 }
 
-impl<TX: Transaction + SystemCallTx> SystemCallTx for RiseTransaction<TX> {
+impl SystemCallTx for RiseTransaction {
     fn new_system_tx_with_caller(
         caller: Address,
         system_contract_address: Address,
         data: Bytes,
     ) -> Self {
-        let mut tx = Self::new(TX::new_system_tx_with_caller(
-            caller,
-            system_contract_address,
-            data,
-        ));
-        tx.enveloped_tx = Some(Bytes::default());
-        tx
+        Self {
+            base: TxEnv::new_system_tx_with_caller(caller, system_contract_address, data),
+            enveloped_tx: Some(Bytes::default()),
+            deposit: DepositTransactionParts::default(),
+        }
     }
 }
 
-impl<T: Transaction> Transaction for RiseTransaction<T> {
-    type AccessListItem<'a>
-        = T::AccessListItem<'a>
-    where
-        T: 'a;
-    type Authorization<'a>
-        = T::Authorization<'a>
-    where
-        T: 'a;
+impl Transaction for RiseTransaction {
+    type AccessListItem<'a> = <TxEnv as Transaction>::AccessListItem<'a>;
+    type Authorization<'a> = <TxEnv as Transaction>::Authorization<'a>;
 
     fn tx_type(&self) -> u8 {
         // Deposits are identified by a non-zero source_hash.
@@ -180,10 +164,10 @@ pub enum RiseTransactionError {
     MissingEnvelopedTx,
 }
 
-impl revm::context_interface::transaction::TransactionError for RiseTransactionError {}
+impl TransactionError for RiseTransactionError {}
 
-impl core::fmt::Display for RiseTransactionError {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for RiseTransactionError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Base(e) => e.fmt(f),
             Self::DepositSystemTxPostRegolith => f.write_str(
@@ -201,15 +185,13 @@ impl core::fmt::Display for RiseTransactionError {
 
 impl core::error::Error for RiseTransactionError {}
 
-impl From<revm::context::result::InvalidTransaction> for RiseTransactionError {
-    fn from(value: revm::context::result::InvalidTransaction) -> Self {
+impl From<InvalidTransaction> for RiseTransactionError {
+    fn from(value: InvalidTransaction) -> Self {
         Self::Base(value)
     }
 }
 
-impl<DBError> From<RiseTransactionError>
-    for revm::context_interface::result::EVMError<DBError, RiseTransactionError>
-{
+impl<DBError> From<RiseTransactionError> for EVMError<DBError, RiseTransactionError> {
     fn from(value: RiseTransactionError) -> Self {
         Self::Transaction(value)
     }

--- a/crates/pevm/src/storage.rs
+++ b/crates/pevm/src/storage.rs
@@ -95,9 +95,12 @@ pub enum EvmCode {
 impl From<EvmCode> for Bytecode {
     fn from(code: EvmCode) -> Self {
         match code {
-            EvmCode::Legacy(code) => {
+            // SAFETY: bytecode was previously analyzed and serialized by pevm with valid
+            // PUSH-padding, so the jump table is consistent with the bytecode bytes.
+            // Reference: https://github.com/bluealloy/revm/pull/3557
+            EvmCode::Legacy(code) => unsafe {
                 Self::new_analyzed(code.bytecode, code.original_len, code.jump_table)
-            }
+            },
             EvmCode::Eip7702(delegated_address) => Self::new_eip7702(delegated_address),
         }
     }


### PR DESCRIPTION
- op-revm <=20.0.0 pins revm = "^38" which is semver-incompatible with revm 39. 
- Vendor the ~dozen types RISE actually needs into crates/pevm/src/op_revm/, stripped of all L1/DA/operator fee arithmetic (RISE zeroes these). 
- Update for revm 39 API changes: Gas::new_spent_with_reservoir, last_frame_result reservoir param, PrecompileProvider::warm_addresses returning &AddressSet, unsafe Bytecode::new_analyzed. 