### PR TITLE
fix: correct zero-value NeedValidation flag in FinishExecFlags

### DIFF
--- a/crates/pevm/src/lib.rs
+++ b/crates/pevm/src/lib.rs
@@ -195,10 +195,10 @@ bitflags! {
         // scheduler, meaning a [false] here will still be validated if
         // there was a lower transaction that has broken the preprocessed
         // dependency chain and returned [true]
-        const NeedValidation = 0;
+        const NeedValidation = 1;
         // We need to validate from the next transaction if this execution
         // wrote to a new location.
-        const WroteNewLocation = 1;
+        const WroteNewLocation = 2;
     }
 }
 


### PR DESCRIPTION
## Bug: `NeedValidation = 0` in `FinishExecFlags` makes the flag always `true`

### Root cause

In `bitflags`, a flag with value `0` is **always "contained"** in any flag set, because:

```
(any_value & 0) == 0  →  always true
```

In `crates/pevm/src/lib.rs`:
```rust
bitflags! {
    struct FinishExecFlags: u8 {
        const NeedValidation  = 0;  // ← BUG: 0-value flag
        const WroteNewLocation = 1;
    }
}
```

This means `flags.contains(FinishExecFlags::NeedValidation)` returns `true` for **every possible value of `flags`**, including `FinishExecFlags::empty()`.

### Impact

In `vm.rs`, the intent is clear:

```rust
// Set NeedValidation for non-lazy, non-first transactions
let mut flags = if tx_version.tx_idx > 0 && !is_lazy {
    FinishExecFlags::NeedValidation   // = 0
} else {
    FinishExecFlags::empty()          // = 0 — identical!
};
```

Both branches produce the same value `0`, so the distinction is lost. In `scheduler::finish_execution()` this has two consequences:

1. **`min_validation_idx` is always updated** — including for lazy transactions (raw ETH transfers) and the first transaction, which should skip validation entirely. This causes the scheduler to schedule unnecessary validation tasks for every single transaction.

2. **`IncarnationStatus::Validated` is never set in `finish_execution`** — the `else` branch that sets `Validated` and increments `num_validated` is unreachable. Every transaction exits `finish_execution` as `Executed` and must go through an explicit `finish_validation` call.

The intended optimisation — skipping validation for lazy transactions (raw transfers, airdrop blocks, busy CEX blocks) and `tx[0]` — never fires.

### Fix

Use distinct non-zero powers of two:

```rust
bitflags! {
    struct FinishExecFlags: u8 {
        const NeedValidation   = 1;
        const WroteNewLocation = 2;
    }
}
```

Now `contains(NeedValidation)` correctly returns `false` for `empty()` (lazy / first tx) and `true` only when the flag is explicitly set.

### Verification

```
Before fix:
  contains(NeedValidation=0, flags=0b00)  →  (0 & 0)==0  →  true  ← always true
  contains(NeedValidation=0, flags=0b01)  →  (1 & 0)==0  →  true  ← always true

After fix:
  contains(NeedValidation=1, flags=0b00)  →  (0 & 1)==1  →  false ← correctly false for lazy/tx[0]
  contains(NeedValidation=1, flags=0b01)  →  (1 & 1)==1  →  true  ← correctly true for normal txs
```
