### PR TITLE
fix: require full block_size validations before scheduler completion

### DIFF
--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -181,7 +181,7 @@ impl Pevm {
         }
 
         let block_size = txs.len();
-        let scheduler = Scheduler::new(block_size);
+        let scheduler = Scheduler::new(block_size, concurrency_level.into());
 
         let mv_memory = chain.build_mv_memory(&block_env, &txs);
 

--- a/crates/pevm/src/scheduler.rs
+++ b/crates/pevm/src/scheduler.rs
@@ -40,6 +40,12 @@ use crate::{FinishExecFlags, IncarnationStatus, Task, TxIdx, TxStatus, TxVersion
 pub(crate) struct Scheduler {
     // The number of transactions in this block.
     block_size: usize,
+    // Total worker threads; used to compute how many are still active.
+    num_threads: usize,
+    // Threads that have exited next_task. A thread may exit early only
+    // when at least `remaining` threads will still be alive after it leaves,
+    // so a cascade re-execution has enough parallelism to resolve.
+    exited_threads: AtomicUsize,
     // The most up-to-date incarnation number (initially 0) and
     // the status of this incarnation.
     // TODO: Consider packing [TxStatus]s into atomics instead of
@@ -65,9 +71,11 @@ pub(crate) struct Scheduler {
 // TODO: Better error handling.
 // Like returning errors instead of panicking on [unreachable]s.
 impl Scheduler {
-    pub(crate) fn new(block_size: usize) -> Self {
+    pub(crate) fn new(block_size: usize, num_threads: usize) -> Self {
         Self {
             block_size,
+            num_threads,
+            exited_threads: AtomicUsize::new(0),
             execution_idx: AtomicUsize::new(0),
             transactions_status: (0..block_size)
                 .map(|_| {
@@ -110,10 +118,21 @@ impl Scheduler {
             let execution_idx = self.execution_idx.load(Ordering::Relaxed);
             let validation_idx = self.validation_idx.load(Ordering::Relaxed);
             if execution_idx >= self.block_size && validation_idx >= self.block_size {
-                // Require all transactions to be validated before any thread exits.
-                // Tail transactions that fail validation need re-execution, and
-                // must not be left with a shrinking thread pool to work with.
-                if self.num_validated.load(Ordering::Relaxed) >= self.block_size {
+                let remaining = self
+                    .block_size
+                    .saturating_sub(self.num_validated.load(Ordering::Relaxed));
+
+                // Allow early exit only if enough threads stay alive for the
+                // remaining work. A re-execution cascade can drive validation_idx
+                // below block_size, which re-wakes any still-spinning threads.
+                if remaining == 0
+                    || self
+                        .exited_threads
+                        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |exited| {
+                            (self.num_threads - exited > remaining).then_some(exited + 1)
+                        })
+                        .is_ok()
+                {
                     break;
                 }
                 thread::yield_now();

--- a/crates/pevm/src/scheduler.rs
+++ b/crates/pevm/src/scheduler.rs
@@ -110,9 +110,10 @@ impl Scheduler {
             let execution_idx = self.execution_idx.load(Ordering::Relaxed);
             let validation_idx = self.validation_idx.load(Ordering::Relaxed);
             if execution_idx >= self.block_size && validation_idx >= self.block_size {
-                if self.num_validated.load(Ordering::Relaxed)
-                    >= self.block_size - self.min_validation_idx.load(Ordering::Relaxed)
-                {
+                // Require all transactions to be validated before any thread exits.
+                // Tail transactions that fail validation need re-execution, and
+                // must not be left with a shrinking thread pool to work with.
+                if self.num_validated.load(Ordering::Relaxed) >= self.block_size {
                     break;
                 }
                 thread::yield_now();


### PR DESCRIPTION
With NeedValidation = 1 (distinct bit values), lazy and first transactions
auto-validate in finish_execution, incrementing num_validated without going
through the validation queue. This left min_validation_idx > 0, making the
completion threshold block_size - min_validation_idx < block_size.

Threads could exit as soon as that lower threshold was met, while the
remaining high-conflict non-lazy tail transactions were still mid
re-execution. Those transactions then ran with a shrinking thread pool,
degrading parallelism on contentious workloads.

Fix: require num_validated >= block_size unconditionally. Auto-validations
still count toward the total, so pure lazy blocks are unaffected; all
threads now stay alive until every transaction's conflict resolution is
complete.

Benchmark:
- NeedValidation = 0
```
Mainnet:
Average: x1.97
Max: x3.97
Min: x0.66

Gigagas:
Raw: 47.715 ms
ERC20: 54.146 ms
Uniswap: 25.270 ms
```
- NeedValidation = 1
```
Average: x1.93
Max: x3.92
Min: x0.67

Raw: 47.287 ms
ERC20: 54.055 ms
Uniswap: 25.179 ms
```
- This PR:
```
Average: x1.97
Max: x3.94
Min: x0.66

Raw: 47.526 ms
ERC20: 53.470 ms
Uniswap: 25.217 ms
```