### PR TITLE
feat: collision-resistant memory-location hashing via seed + u64 tag

### DIFF
--- a/crates/pevm/src/chain.rs
+++ b/crates/pevm/src/chain.rs
@@ -25,7 +25,7 @@ use revm::{
 };
 use smallvec::SmallVec;
 
-use crate::{MemoryLocationHash, PevmTxExecutionResult, mv_memory::MvMemory};
+use crate::{LocationTag, MemoryLocationHash, PevmTxExecutionResult, mv_memory::MvMemory};
 
 /// The error type of [`PevmChain::calculate_receipt_root`]
 #[derive(Debug, Clone)]
@@ -139,20 +139,24 @@ pub trait PevmChain: Debug {
         true
     }
 
-    /// Build [`MvMemory`]
-    fn build_mv_memory(&self, _block_env: &BlockEnv, txs: &[Self::EvmTx]) -> MvMemory {
-        MvMemory::new(txs.len(), [], [])
+    /// Build [`MvMemory`]. `seed` is the per-execution random seed that must be
+    /// mixed into every location hash & tag (see [`crate::hash_deterministic`]).
+    fn build_mv_memory(&self, _block_env: &BlockEnv, txs: &[Self::EvmTx], seed: u64) -> MvMemory {
+        MvMemory::new(seed, txs.len(), [], [])
     }
 
-    /// Get rewards (balance increments) to beneficiary accounts, etc.
+    /// Get rewards (balance increments) to beneficiary accounts, etc. Returns each
+    /// recipient's location hash, its verification tag, and the increment. `seed` is
+    /// needed to derive the hash & tag of any chain-specific fee recipients.
     fn get_rewards(
         &self,
-        beneficiary_location_hash: u64,
+        beneficiary: (MemoryLocationHash, LocationTag),
         gas_used: U256,
         gas_price: U256,
         basefee: u64,
+        seed: u64,
         tx: &Self::EvmTx,
-    ) -> SmallVec<[(MemoryLocationHash, U256); 1]>;
+    ) -> SmallVec<[(MemoryLocationHash, LocationTag, U256); 1]>;
 
     /// Calculate receipt root
     fn calculate_receipt_root(

--- a/crates/pevm/src/chain/ethereum.rs
+++ b/crates/pevm/src/chain/ethereum.rs
@@ -22,8 +22,8 @@ use smallvec::SmallVec;
 
 use super::{CalculateReceiptRootError, PevmChain};
 use crate::{
-    BuildIdentityHasher, MemoryLocation, MemoryLocationHash, PevmTxExecutionResult, TxIdx,
-    hash_deterministic, mv_memory::MvMemory,
+    BuildIdentityHasher, LocationTag, MemoryLocation, MemoryLocationHash, PevmTxExecutionResult,
+    TxIdx, hash_deterministic, mv_memory::MvMemory, tag_deterministic,
 };
 
 /// Implementation of [`PevmChain`] for Ethereum
@@ -163,31 +163,44 @@ impl PevmChain for PevmEthereum {
         tx
     }
 
-    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[TxEnv]) -> MvMemory {
+    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[TxEnv], seed: u64) -> MvMemory {
         let block_size = txs.len();
-        let beneficiary_location_hash =
-            hash_deterministic(MemoryLocation::Basic(block_env.beneficiary));
+        let beneficiary = MemoryLocation::Basic(block_env.beneficiary);
+        let beneficiary_location_hash = hash_deterministic(beneficiary.clone(), seed);
+        let beneficiary_location_tag = tag_deterministic(beneficiary, seed);
 
         // TODO: Estimate more locations based on sender, to, etc.
         let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());
         estimated_locations.insert(
             beneficiary_location_hash,
-            (0..block_size).collect::<Vec<TxIdx>>(),
+            (
+                beneficiary_location_tag,
+                (0..block_size).collect::<Vec<TxIdx>>(),
+            ),
         );
 
-        MvMemory::new(block_size, estimated_locations, [block_env.beneficiary])
+        MvMemory::new(
+            seed,
+            block_size,
+            estimated_locations
+                .into_iter()
+                .map(|(hash, (tag, tx_idxs))| (hash, tag, tx_idxs)),
+            [block_env.beneficiary],
+        )
     }
 
     fn get_rewards(
         &self,
-        beneficiary_location_hash: u64,
+        beneficiary: (MemoryLocationHash, LocationTag),
         gas_used: U256,
         gas_price: U256,
         _: u64,
+        _: u64,
         _: &Self::EvmTx,
-    ) -> SmallVec<[(MemoryLocationHash, U256); 1]> {
+    ) -> SmallVec<[(MemoryLocationHash, LocationTag, U256); 1]> {
         smallvec::smallvec![(
-            beneficiary_location_hash,
+            beneficiary.0,
+            beneficiary.1,
             gas_price.saturating_mul(gas_used)
         )]
     }

--- a/crates/pevm/src/chain/rise.rs
+++ b/crates/pevm/src/chain/rise.rs
@@ -1,6 +1,4 @@
 //! RISE
-use std::sync::LazyLock;
-
 use alloy_consensus::Transaction;
 use alloy_primitives::{Address, B256, ChainId, U256};
 use alloy_rpc_types_eth::{BlockTransactions, Header};
@@ -22,22 +20,24 @@ use revm::{
 use smallvec::SmallVec;
 
 use crate::{
-    BuildIdentityHasher, MemoryLocation, MemoryLocationHash, PevmTxExecutionResult,
-    hash_deterministic, mv_memory::MvMemory,
+    BuildIdentityHasher, LocationTag, MemoryLocation, MemoryLocationHash, PevmTxExecutionResult,
+    hash_deterministic, mv_memory::MvMemory, tag_deterministic,
 };
 
 use super::{CalculateReceiptRootError, PevmChain};
 
 const RISE_CHAIN_ID: ChainId = 4153; // Mainnet
 
-static BASE_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
-    LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(BASE_FEE_RECIPIENT)));
-
-static L1_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
-    LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(L1_FEE_RECIPIENT)));
-
-static OPERATOR_FEE_RECIPIENT_LOCATION_HASH: LazyLock<MemoryLocationHash> =
-    LazyLock::new(|| hash_deterministic(MemoryLocation::Basic(OPERATOR_FEE_RECIPIENT)));
+// Compute the (hash, tag) pair of a basic-account location under the per-block seed.
+// The fee recipients are fixed addresses, but a per-execution seed means their
+// fingerprints cannot be precomputed once, so we derive them per block here.
+#[inline]
+fn basic_hash_and_tag(address: Address, seed: u64) -> (MemoryLocationHash, LocationTag) {
+    (
+        hash_deterministic(MemoryLocation::Basic(address), seed),
+        tag_deterministic(MemoryLocation::Basic(address), seed),
+    )
+}
 
 /// Implementation of [`PevmChain`] for RISE
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -105,74 +105,81 @@ impl PevmChain for PevmRise {
             .build_op()
     }
 
-    fn build_mv_memory(&self, block_env: &BlockEnv, txs: &[OpTransaction<TxEnv>]) -> MvMemory {
-        let beneficiary_location_hash =
-            hash_deterministic(MemoryLocation::Basic(block_env.beneficiary));
+    fn build_mv_memory(
+        &self,
+        block_env: &BlockEnv,
+        txs: &[OpTransaction<TxEnv>],
+        seed: u64,
+    ) -> MvMemory {
+        // The beneficiary and the three fee recipients are written by every
+        // non-deposit transaction, so we pre-seed them as estimates.
+        let recipients = [
+            block_env.beneficiary,
+            BASE_FEE_RECIPIENT,
+            L1_FEE_RECIPIENT,
+            OPERATOR_FEE_RECIPIENT,
+        ];
 
         // TODO: Estimate more locations based on sender, to, etc.
         // TODO: Benchmark to check whether adding these estimated
         // locations helps or harms the performance.
         let mut estimated_locations = HashMap::with_hasher(BuildIdentityHasher::default());
-
         for (index, tx) in txs.iter().enumerate() {
             // Deposit transactions pay no fees so they write nothing to these fee recipients.
             if !tx.is_deposit() {
-                estimated_locations
-                    .entry(beneficiary_location_hash)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
-                estimated_locations
-                    .entry(*BASE_FEE_RECIPIENT_LOCATION_HASH)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
-                estimated_locations
-                    .entry(*L1_FEE_RECIPIENT_LOCATION_HASH)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
-                estimated_locations
-                    .entry(*OPERATOR_FEE_RECIPIENT_LOCATION_HASH)
-                    .or_insert_with(|| Vec::with_capacity(txs.len()))
-                    .push(index);
+                for address in recipients {
+                    let (hash, tag) = basic_hash_and_tag(address, seed);
+                    estimated_locations
+                        .entry(hash)
+                        .or_insert_with(|| (tag, Vec::with_capacity(txs.len())))
+                        .1
+                        .push(index);
+                }
             }
         }
 
         MvMemory::new(
+            seed,
             txs.len(),
-            estimated_locations,
-            [
-                block_env.beneficiary,
-                BASE_FEE_RECIPIENT,
-                L1_FEE_RECIPIENT,
-                OPERATOR_FEE_RECIPIENT,
-            ],
+            estimated_locations
+                .into_iter()
+                .map(|(hash, (tag, tx_idxs))| (hash, tag, tx_idxs)),
+            recipients,
         )
     }
 
     fn get_rewards(
         &self,
-        beneficiary_location_hash: u64,
+        beneficiary: (MemoryLocationHash, LocationTag),
         gas_used: U256,
         gas_price: U256,
         basefee: u64,
+        seed: u64,
         tx: &Self::EvmTx,
-    ) -> SmallVec<[(MemoryLocationHash, U256); 1]> {
+    ) -> SmallVec<[(MemoryLocationHash, LocationTag, U256); 1]> {
         if tx.is_deposit() {
             SmallVec::new()
         } else {
+            let (base_fee_hash, base_fee_tag) = basic_hash_and_tag(BASE_FEE_RECIPIENT, seed);
+            let (l1_fee_hash, l1_fee_tag) = basic_hash_and_tag(L1_FEE_RECIPIENT, seed);
+            let (operator_fee_hash, operator_fee_tag) =
+                basic_hash_and_tag(OPERATOR_FEE_RECIPIENT, seed);
             smallvec::smallvec![
                 (
-                    beneficiary_location_hash,
+                    beneficiary.0,
+                    beneficiary.1,
                     gas_price.saturating_mul(gas_used)
                 ),
                 (
-                    *BASE_FEE_RECIPIENT_LOCATION_HASH,
+                    base_fee_hash,
+                    base_fee_tag,
                     U256::from(basefee).saturating_mul(gas_used),
                 ),
                 // RISE disables DA footprint and operator fees. Annoyingly, we still
                 // need to touch these to match revm's sequential execution for now.
                 // Will remove once we rewrite our own EVM implementation.
-                (*L1_FEE_RECIPIENT_LOCATION_HASH, U256::ZERO),
-                (*OPERATOR_FEE_RECIPIENT_LOCATION_HASH, U256::ZERO),
+                (l1_fee_hash, l1_fee_tag, U256::ZERO),
+                (operator_fee_hash, operator_fee_tag, U256::ZERO),
             ]
         }
     }

--- a/crates/pevm/src/lib.rs
+++ b/crates/pevm/src/lib.rs
@@ -43,6 +43,14 @@ enum MemoryLocation {
 // on every single lookup & validation.
 type MemoryLocationHash = u64;
 
+// A second, independently seeded fingerprint of a memory location, stored
+// alongside each value in the multi-version data. Because [MemoryLocationHash]
+// is also the map key, two distinct locations that collide in the hash would
+// otherwise share an entry; comparing this tag on read disambiguates them, so
+// a collision is only harmful if both the hash AND the tag collide at once
+// (~2^-128). See [tag_deterministic].
+type LocationTag = u64;
+
 /// This is primarily used for memory location hash, but can also be used for
 /// transaction indexes, etc.
 #[derive(Debug, Default)]
@@ -65,11 +73,22 @@ impl Hasher for IdentityHasher {
 /// Build an identity hasher
 pub type BuildIdentityHasher = BuildHasherDefault<IdentityHasher>;
 
-// TODO: Ensure it's not easy to hand-craft transactions and storage slots
-// that can cause a lot of collisions that destroys pevm's performance.
+// Memory locations are hashed into two independent fingerprints, both mixed
+// with a per-execution random [seed]. The [hash_deterministic] output keys the
+// multi-version data; the [tag_deterministic] output is stored in each entry and
+// compared on read. The seed makes collisions impossible for an attacker to aim
+// at (it is unknown until the block runs), and the second fingerprint makes any
+// collision that still occurs at random harmless unless both halves collide
+// (~2^-128). The two passes use decorrelated seeds (`seed` and `!seed`) so that
+// colliding in one does not imply colliding in the other.
 #[inline(always)]
-fn hash_deterministic<T: Hash>(x: T) -> u64 {
-    FxBuildHasher.hash_one(x)
+fn hash_deterministic<T: Hash>(x: T, seed: u64) -> MemoryLocationHash {
+    FxBuildHasher.hash_one((seed, x))
+}
+
+#[inline(always)]
+fn tag_deterministic<T: Hash>(x: T, seed: u64) -> LocationTag {
+    FxBuildHasher.hash_one((!seed, x))
 }
 
 // TODO: It would be nice if we could tie the different cases of
@@ -96,7 +115,10 @@ enum MemoryValue {
 
 #[derive(Debug)]
 enum MemoryEntry {
-    Data(TxIncarnation, MemoryValue),
+    // Both variants carry the [LocationTag] of the location they belong to, so a
+    // reader scanning a hash bucket can skip entries written by a colliding
+    // neighbor location instead of mistaking them for its own.
+    Data(TxIncarnation, LocationTag, MemoryValue),
     // When an incarnation is aborted due to a validation failure, the
     // entries in the multi-version data structure corresponding to its
     // write set are replaced with this special ESTIMATE marker.
@@ -107,7 +129,18 @@ enum MemoryEntry {
     // and aborting during validation.
     // The ESTIMATE markers that are not overwritten are removed by the next
     // incarnation.
-    Estimate,
+    Estimate(LocationTag),
+}
+
+impl MemoryEntry {
+    // The verification tag of the location this entry belongs to. A reader skips
+    // entries whose tag differs from the location it is reading.
+    #[inline(always)]
+    const fn tag(&self) -> LocationTag {
+        match self {
+            Self::Data(_, tag, _) | Self::Estimate(tag) => *tag,
+        }
+    }
 }
 
 // The index of the transaction in the block.
@@ -174,8 +207,9 @@ type ReadOrigins = SmallVec<[ReadOrigin; 1]>;
 type ReadSet = HashMap<MemoryLocationHash, ReadOrigins, BuildIdentityHasher>;
 
 // The updates made by this transaction incarnation, which is applied
-// to the multi-version data structure at the end of execution.
-type WriteSet = Vec<(MemoryLocationHash, MemoryValue)>;
+// to the multi-version data structure at the end of execution. Each entry
+// carries the location's hash (map key), its verification tag, and the value.
+type WriteSet = Vec<(MemoryLocationHash, LocationTag, MemoryValue)>;
 
 // A scheduled worker task
 // TODO: Add more useful work when there are idle workers like near

--- a/crates/pevm/src/mv_memory.rs
+++ b/crates/pevm/src/mv_memory.rs
@@ -8,15 +8,16 @@ use dashmap::DashMap;
 use revm::state::Bytecode;
 
 use crate::{
-    BuildIdentityHasher, BuildSuffixHasher, MemoryEntry, MemoryLocationHash, ReadOrigin, ReadSet,
-    TxIdx, TxVersion, WriteSet,
+    BuildIdentityHasher, BuildSuffixHasher, LocationTag, MemoryEntry, MemoryLocationHash,
+    ReadOrigin, ReadSet, TxIdx, TxVersion, WriteSet,
 };
 
 #[derive(Default, Debug)]
 struct LastLocations {
     read: ReadSet,
+    // The hash (map key) and tag of each location this transaction last wrote to.
     // Consider [SmallVec] since most transactions explicitly write to 2 locations!
-    write: Vec<MemoryLocationHash>,
+    write: Vec<(MemoryLocationHash, LocationTag)>,
 }
 
 type LazyAddresses = HashSet<Address, BuildSuffixHasher>;
@@ -39,12 +40,16 @@ pub struct MvMemory {
     lazy_addresses: Mutex<LazyAddresses>,
     /// New bytecodes deployed in this block
     pub(crate) new_bytecodes: DashMap<B256, Bytecode, BuildSuffixHasher>,
+    /// Per-execution random seed mixed into every location hash & tag. Unknown to
+    /// transaction submitters until the block runs, so collisions cannot be aimed at.
+    pub(crate) seed: u64,
 }
 
 impl MvMemory {
     pub(crate) fn new(
+        seed: u64,
         block_size: usize,
-        estimated_locations: impl IntoIterator<Item = (MemoryLocationHash, Vec<TxIdx>)>,
+        estimated_locations: impl IntoIterator<Item = (MemoryLocationHash, LocationTag, Vec<TxIdx>)>,
         lazy_addresses: impl IntoIterator<Item = Address>,
     ) -> Self {
         // TODO: Fine-tune the number of shards, like to the next number of two from the
@@ -54,12 +59,12 @@ impl MvMemory {
         // while holding a write lock. Ideally [dashmap] would have a lock-free
         // construction API. This is acceptable for now as it's a non-congested one-time
         // cost.
-        for (location_hash, estimated_tx_idxs) in estimated_locations {
+        for (location_hash, location_tag, estimated_tx_idxs) in estimated_locations {
             data.insert(
                 location_hash,
                 estimated_tx_idxs
                     .into_iter()
-                    .map(|tx_idx| (tx_idx, MemoryEntry::Estimate))
+                    .map(|tx_idx| (tx_idx, MemoryEntry::Estimate(location_tag)))
                     .collect(),
             );
         }
@@ -70,6 +75,7 @@ impl MvMemory {
             // TODO: Fine-tune the number of shards, like to the next number of two from the
             // number of worker threads.
             new_bytecodes: DashMap::default(),
+            seed,
         }
     }
 
@@ -97,9 +103,9 @@ impl MvMemory {
         // Remove old locations that aren't written to anymore.
         let mut last_location_idx = 0;
         while last_location_idx < last_locations.write.len() {
-            let prev_location = unsafe { last_locations.write.get_unchecked(last_location_idx) };
-            if write_set.iter().all(|(l, _)| l != prev_location) {
-                if let Some(mut written_transactions) = self.data.get_mut(prev_location) {
+            let prev_location = unsafe { *last_locations.write.get_unchecked(last_location_idx) };
+            if write_set.iter().all(|(l, t, _)| (*l, *t) != prev_location) {
+                if let Some(mut written_transactions) = self.data.get_mut(&prev_location.0) {
                     written_transactions.remove(&tx_version.tx_idx);
                 }
                 last_locations.write.swap_remove(last_location_idx);
@@ -111,13 +117,17 @@ impl MvMemory {
         // Register new writes.
         let mut wrote_new_location = false;
 
-        for (location, value) in write_set {
+        for (location, tag, value) in write_set {
             self.data.entry(location).or_default().insert(
                 tx_version.tx_idx,
-                MemoryEntry::Data(tx_version.tx_incarnation, value),
+                MemoryEntry::Data(tx_version.tx_incarnation, tag, value),
             );
-            if !last_locations.write.contains(&location) {
-                last_locations.write.push(location);
+            if !last_locations
+                .write
+                .iter()
+                .any(|(l, t)| *l == location && *t == tag)
+            {
+                last_locations.write.push((location, tag));
                 wrote_new_location = true;
             }
         }
@@ -179,9 +189,9 @@ impl MvMemory {
     // structure with special ESTIMATE markers to quickly abort higher transactions
     // that read them.
     pub(crate) fn convert_writes_to_estimates(&self, tx_idx: TxIdx) {
-        for location in &index_mutex!(self.last_locations, tx_idx).write {
+        for (location, tag) in &index_mutex!(self.last_locations, tx_idx).write {
             if let Some(mut written_transactions) = self.data.get_mut(location) {
-                written_transactions.insert(tx_idx, MemoryEntry::Estimate);
+                written_transactions.insert(tx_idx, MemoryEntry::Estimate(*tag));
             }
         }
     }

--- a/crates/pevm/src/pevm.rs
+++ b/crates/pevm/src/pevm.rs
@@ -1,6 +1,7 @@
 use std::{
     cell::UnsafeCell,
     fmt::Debug,
+    hash::{BuildHasher, RandomState},
     num::NonZeroUsize,
     sync::{OnceLock, mpsc},
     thread,
@@ -27,6 +28,7 @@ use crate::{
     mv_memory::MvMemory,
     scheduler::Scheduler,
     storage::StorageWrapper,
+    tag_deterministic,
     vm::{
         ExecutionError, PevmTxExecutionResult, Vm, VmExecutionError, receipt_from_revm,
         state_transitions_from_revm,
@@ -224,7 +226,13 @@ impl Pevm {
         let block_size = txs.len();
         let scheduler = Scheduler::new(block_size);
 
-        let mv_memory = chain.build_mv_memory(&block_env, &txs);
+        // A per-execution random seed mixed into every location hash & tag. It is
+        // unknown to transaction submitters until the block runs, so hash collisions
+        // cannot be crafted to target this block. The seed never escapes into the
+        // results (state is keyed by real addresses), so output is identical for any
+        // seed. We derive a u64 from the OS-seeded [RandomState] to avoid a dependency.
+        let seed = RandomState::new().hash_one(0u8);
+        let mv_memory = chain.build_mv_memory(&block_env, &txs, seed);
 
         self.execution_results.grow_to(block_size);
 
@@ -288,14 +296,16 @@ impl Pevm {
         // We fully evaluate (the balance and nonce of) the beneficiary account
         // and raw transfer recipients that may have been atomically updated.
         for address in mv_memory.consume_lazy_addresses() {
-            let location_hash = hash_deterministic(MemoryLocation::Basic(address));
+            let location_hash = hash_deterministic(MemoryLocation::Basic(address), mv_memory.seed);
+            let location_tag = tag_deterministic(MemoryLocation::Basic(address), mv_memory.seed);
             if let Some(write_history) = mv_memory.data.get(&location_hash) {
                 let mut balance = U256::ZERO;
                 let mut nonce = 0;
-                // Read from storage if the first multi-version entry is not an absolute value.
+                // Read from storage if the first multi-version entry of this location
+                // (skipping any colliding neighbor) is not an absolute value.
                 if !matches!(
-                    write_history.first_key_value(),
-                    Some((_, MemoryEntry::Data(_, MemoryValue::Basic(_))))
+                    write_history.iter().find(|(_, e)| e.tag() == location_tag),
+                    Some((_, MemoryEntry::Data(_, _, MemoryValue::Basic(_))))
                 ) && let Ok(Some(account)) = storage.basic(&address)
                 {
                     balance = account.balance;
@@ -316,19 +326,23 @@ impl Pevm {
                 };
 
                 for (tx_idx, memory_entry) in write_history.iter() {
+                    // Skip entries belonging to a colliding neighbor location.
+                    if memory_entry.tag() != location_tag {
+                        continue;
+                    }
                     let tx = chain.tx_env(unsafe { txs.get_unchecked(*tx_idx) });
                     match memory_entry {
-                        MemoryEntry::Data(_, MemoryValue::Basic(info)) => {
+                        MemoryEntry::Data(_, _, MemoryValue::Basic(info)) => {
                             // We fall back to sequential execution when reading a self-destructed account,
                             // so an empty account here would be a bug
                             debug_assert!(!(info.balance.is_zero() && info.nonce == 0));
                             balance = info.balance;
                             nonce = info.nonce;
                         }
-                        MemoryEntry::Data(_, MemoryValue::LazyRecipient(addition)) => {
+                        MemoryEntry::Data(_, _, MemoryValue::LazyRecipient(addition)) => {
                             balance = balance.saturating_add(*addition);
                         }
-                        MemoryEntry::Data(_, MemoryValue::LazySender(subtraction)) => {
+                        MemoryEntry::Data(_, _, MemoryValue::LazySender(subtraction)) => {
                             // We must re-do extra sender balance checks as we mock
                             // the max value in [Vm] during execution. Ideally we
                             // can turn off these redundant checks in revm.

--- a/crates/pevm/src/vm.rs
+++ b/crates/pevm/src/vm.rs
@@ -14,9 +14,10 @@ use revm::{
 use smallvec::SmallVec;
 
 use crate::{
-    AccountBasic, BuildIdentityHasher, BuildSuffixHasher, EvmAccount, FinishExecFlags, MemoryEntry,
-    MemoryLocation, MemoryLocationHash, MemoryValue, ReadOrigin, ReadOrigins, ReadSet, Storage,
-    TxIdx, TxVersion, WriteSet, chain::PevmChain, hash_deterministic, mv_memory::MvMemory,
+    AccountBasic, BuildIdentityHasher, BuildSuffixHasher, EvmAccount, FinishExecFlags, LocationTag,
+    MemoryEntry, MemoryLocation, MemoryLocationHash, MemoryValue, ReadOrigin, ReadOrigins, ReadSet,
+    Storage, TxIdx, TxVersion, WriteSet, chain::PevmChain, hash_deterministic, mv_memory::MvMemory,
+    tag_deterministic,
 };
 
 /// The execution error from the underlying EVM executor.
@@ -182,7 +183,7 @@ impl<'a, S: Storage> VmDb<'a, S> {
         {
             return self.to_hash.unwrap();
         }
-        hash_deterministic(MemoryLocation::Basic(*address))
+        hash_deterministic(MemoryLocation::Basic(*address), self.mv_memory.seed)
     }
 
     // Push a new read origin. Return an error when there's already
@@ -199,15 +200,20 @@ impl<'a, S: Storage> VmDb<'a, S> {
     }
 
     fn get_code_hash(&mut self, address: Address) -> Result<Option<B256>, ReadError> {
-        let location_hash = hash_deterministic(MemoryLocation::CodeHash(address));
+        let seed = self.mv_memory.seed;
+        let location_hash = hash_deterministic(MemoryLocation::CodeHash(address), seed);
+        let location_tag = tag_deterministic(MemoryLocation::CodeHash(address), seed);
         let read_origins = self.read_set.entry(location_hash).or_default();
 
         // Try to read the latest code hash in [MvMemory]
         // TODO: Memoize read locations (expected to be small) here in [Vm] to avoid
         // contention in [MvMemory]
         if let Some(written_transactions) = self.mv_memory.data.get(&location_hash)
-            && let Some((tx_idx, MemoryEntry::Data(tx_incarnation, value))) =
-                written_transactions.range(..self.tx_idx).next_back()
+            && let Some((tx_idx, MemoryEntry::Data(tx_incarnation, _, value))) =
+                written_transactions
+                    .range(..self.tx_idx)
+                    .rev()
+                    .find(|(_, entry)| entry.tag() == location_tag)
         {
             match value {
                 MemoryValue::SelfDestructed => {
@@ -240,6 +246,7 @@ impl<S: Storage> Database for VmDb<'_, S> {
 
     fn basic(&mut self, address: Address) -> Result<Option<AccountInfo>, Self::Error> {
         let location_hash = self.hash_basic(&address);
+        let location_tag = tag_deterministic(MemoryLocation::Basic(address), self.mv_memory.seed);
 
         // We return a mock for non-contract addresses (for lazy updates) to avoid
         // unnecessarily evaluating its balance here.
@@ -279,10 +286,12 @@ impl<S: Storage> Database for VmDb<'_, S> {
             // Fully evaluate lazy updates
             loop {
                 match iter.next_back() {
-                    Some((blocking_idx, MemoryEntry::Estimate)) => {
+                    // Skip entries belonging to a colliding neighbor location.
+                    Some((_, entry)) if entry.tag() != location_tag => continue,
+                    Some((blocking_idx, MemoryEntry::Estimate(_))) => {
                         return Err(ReadError::Blocking(*blocking_idx));
                     }
-                    Some((closest_idx, MemoryEntry::Data(tx_incarnation, value))) => {
+                    Some((closest_idx, MemoryEntry::Data(tx_incarnation, _, value))) => {
                         // About to push a new origin
                         // Inconsistent: new origin will be longer than the previous!
                         if has_prev_origins && read_origins.len() == new_origins.len() {
@@ -427,18 +436,22 @@ impl<S: Storage> Database for VmDb<'_, S> {
     }
 
     fn storage(&mut self, address: Address, index: U256) -> Result<U256, Self::Error> {
-        let location_hash = hash_deterministic(MemoryLocation::Storage(address, index));
+        let seed = self.mv_memory.seed;
+        let location_hash = hash_deterministic(MemoryLocation::Storage(address, index), seed);
+        let location_tag = tag_deterministic(MemoryLocation::Storage(address, index), seed);
 
         let read_origins = self.read_set.entry(location_hash).or_default();
 
         // Try reading from multi-version data
         if self.tx_idx > 0
             && let Some(written_transactions) = self.mv_memory.data.get(&location_hash)
-            && let Some((closest_idx, entry)) =
-                written_transactions.range(..self.tx_idx).next_back()
+            && let Some((closest_idx, entry)) = written_transactions
+                .range(..self.tx_idx)
+                .rev()
+                .find(|(_, entry)| entry.tag() == location_tag)
         {
             match entry {
-                MemoryEntry::Data(tx_incarnation, MemoryValue::Storage(value)) => {
+                MemoryEntry::Data(tx_incarnation, _, MemoryValue::Storage(value)) => {
                     Self::push_origin(
                         read_origins,
                         ReadOrigin::MvMemory(TxVersion {
@@ -448,7 +461,7 @@ impl<S: Storage> Database for VmDb<'_, S> {
                     )?;
                     return Ok(*value);
                 }
-                MemoryEntry::Estimate => return Err(ReadError::Blocking(*closest_idx)),
+                MemoryEntry::Estimate(_) => return Err(ReadError::Blocking(*closest_idx)),
                 _ => return Err(ReadError::InvalidMemoryValueType),
             }
         }
@@ -476,6 +489,7 @@ pub(crate) struct Vm<'a, S: Storage, C: PevmChain> {
     txs: &'a [C::EvmTx],
     mv_memory: &'a MvMemory,
     beneficiary_location_hash: MemoryLocationHash,
+    beneficiary_location_tag: LocationTag,
     // Dedicated EVM for the worker, reset before each transaction exectution.
     evm: C::Evm<VmDb<'a, S>>,
 }
@@ -513,9 +527,14 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
             block_env,
             txs,
             mv_memory,
-            beneficiary_location_hash: hash_deterministic(MemoryLocation::Basic(
-                block_env.beneficiary,
-            )),
+            beneficiary_location_hash: hash_deterministic(
+                MemoryLocation::Basic(block_env.beneficiary),
+                mv_memory.seed,
+            ),
+            beneficiary_location_tag: tag_deterministic(
+                MemoryLocation::Basic(block_env.beneficiary),
+                mv_memory.seed,
+            ),
             evm: chain.build_evm(spec_id, block_env.clone(), db),
         }
     }
@@ -545,11 +564,12 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
         let full_tx = unsafe { self.txs.get_unchecked(tx_version.tx_idx) };
         let tx = self.chain.tx_env(full_tx);
 
-        let from_hash = hash_deterministic(MemoryLocation::Basic(tx.caller));
+        let seed = self.mv_memory.seed;
+        let from_hash = hash_deterministic(MemoryLocation::Basic(tx.caller), seed);
         let to_hash = tx
             .kind
             .to()
-            .map(|to| hash_deterministic(MemoryLocation::Basic(*to)));
+            .map(|to| hash_deterministic(MemoryLocation::Basic(*to), seed));
 
         let has_nonce = self.chain.has_nonce(&mut self.evm, full_tx);
 
@@ -584,7 +604,8 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                         // For now we are betting on [code_hash] triggering the sequential
                         // fallback when we read a self-destructed contract.
                         write_set.push((
-                            hash_deterministic(MemoryLocation::CodeHash(*address)),
+                            hash_deterministic(MemoryLocation::CodeHash(*address), seed),
+                            tag_deterministic(MemoryLocation::CodeHash(*address), seed),
                             MemoryValue::SelfDestructed,
                         ));
                         continue;
@@ -592,7 +613,9 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
 
                     if account.is_touched() {
                         let account_location_hash =
-                            hash_deterministic(MemoryLocation::Basic(*address));
+                            hash_deterministic(MemoryLocation::Basic(*address), seed);
+                        let account_location_tag =
+                            tag_deterministic(MemoryLocation::Basic(*address), seed);
                         let read_account = ctx.db().read_accounts.get(&account_location_hash);
 
                         let has_code = !account.info.is_empty_code_hash();
@@ -611,11 +634,13 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                                 if account_location_hash == from_hash {
                                     write_set.push((
                                         account_location_hash,
+                                        account_location_tag,
                                         MemoryValue::LazySender(U256::MAX - account.info.balance),
                                     ));
                                 } else if Some(account_location_hash) == to_hash {
                                     write_set.push((
                                         account_location_hash,
+                                        account_location_tag,
                                         MemoryValue::LazyRecipient(tx.value),
                                     ));
                                 }
@@ -631,6 +656,7 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                             else if !self.is_eip_161_enabled || !account.is_empty() {
                                 write_set.push((
                                     account_location_hash,
+                                    account_location_tag,
                                     MemoryValue::Basic(AccountBasic {
                                         balance: account.info.balance,
                                         nonce: account.info.nonce,
@@ -642,7 +668,8 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                         // Write new contract
                         if is_new_code {
                             write_set.push((
-                                hash_deterministic(MemoryLocation::CodeHash(*address)),
+                                hash_deterministic(MemoryLocation::CodeHash(*address), seed),
+                                tag_deterministic(MemoryLocation::CodeHash(*address), seed),
                                 MemoryValue::CodeHash(account.info.code_hash),
                             ));
                             self.mv_memory
@@ -655,7 +682,8 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     // TODO: We should move this changed check to our read set like for account info?
                     for (slot, value) in account.changed_storage_slots() {
                         write_set.push((
-                            hash_deterministic(MemoryLocation::Storage(*address, *slot)),
+                            hash_deterministic(MemoryLocation::Storage(*address, *slot), seed),
+                            tag_deterministic(MemoryLocation::Storage(*address, *slot), seed),
                             MemoryValue::Storage(value.present_value),
                         ));
                     }
@@ -674,16 +702,20 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                     gas_price = gas_price.saturating_sub(self.block_env.basefee as u128);
                 }
                 let rewards = self.chain.get_rewards(
-                    self.beneficiary_location_hash,
+                    (
+                        self.beneficiary_location_hash,
+                        self.beneficiary_location_tag,
+                    ),
                     U256::from(exec_result.tx_gas_used()),
                     U256::from(gas_price),
                     self.block_env.basefee,
+                    seed,
                     full_tx,
                 );
-                for (recipient, amount) in rewards {
-                    if let Some((_, value)) = write_set
+                for (recipient, recipient_tag, amount) in rewards {
+                    if let Some((_, _, value)) = write_set
                         .iter_mut()
-                        .find(|(location, _)| location == &recipient)
+                        .find(|(location, _, _)| *location == recipient)
                     {
                         match value {
                             MemoryValue::Basic(basic) => {
@@ -698,7 +730,11 @@ impl<'a, S: Storage, C: PevmChain> Vm<'a, S, C> {
                             _ => return Err(ReadError::InvalidMemoryValueType.into()),
                         }
                     } else {
-                        write_set.push((recipient, MemoryValue::LazyRecipient(amount)));
+                        write_set.push((
+                            recipient,
+                            recipient_tag,
+                            MemoryValue::LazyRecipient(amount),
+                        ));
                     }
                 }
 


### PR DESCRIPTION
## Problem

`MemoryLocationHash = u64` is used **as the `MvMemory` map key itself**, so it doubles as both the bucket key and the location's identity. Two distinct locations that collide in the `u64` share one entry:

- **Targeted:** FxHash is non-cryptographic and algebraically invertible — an attacker can craft a storage slot that collides with another location for ~free, making a read return the wrong value (which then validates cleanly) → **wrong state / chain fork**, or flood one bucket → **DoS**.
- **Random:** any 64-bit key collides at the ~2³² birthday bound (~10⁻¹⁰–10⁻¹² per block).

## Fix — two cheap, independent levers

1. **Per-execution random seed** mixed into every location hash & tag. Unknown to transaction submitters until the block runs, so collisions cannot be aimed at this block. Derived from `RandomState` (no new dependency) and stored on `MvMemory`.
2. **Per-entry verification tag** — a second, independently seeded fingerprint (`!seed`) stored in each `MemoryEntry`. Reads skip entries whose tag differs from the location being read, so a collision is only harmful if **both** the hash and the tag collide (~2⁻¹²⁸). This restores the key-comparison a normal `HashMap` does, without widening the `u64` map key.

The seed never escapes into results (state is keyed by real `Address`es), so **output is identical for any seed**.

## Cost

Read path (common, no-collision case): one extra `u64` compare + one extra hash per location. Per block: one `RandomState::new()`.

## Residual (documented, adversarially unreachable)

`ReadSet` / validation stay keyed by the bare `u64` hash, so two colliding locations touched by one tx can still conflate there — but that only ever forces a **spurious re-execution (liveness), never wrong state**, and the secret seed makes it impossible to trigger on purpose.

## Verification

- `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace --release -- --test-threads=1` — **all green**, including the full `ethereum/tests` state-test suite, RISE/mainnet/uniswap blocks (these compare pevm output to expected/sequential, proving the change is output-preserving)

Benchmarks (`gigagas`, `mainnet`) pending — opening as draft for perf review.