### PR TITLE
[codex] ci: replace hand-rolled cache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # TODO: Tighter cache control.
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo
-            ./target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
 
       - uses: bnjbvr/cargo-machete@main
 


### PR DESCRIPTION
## Summary
Replace the hand-rolled Cargo cache step in CI with `Swatinem/rust-cache@v2`.

## Why
The current workflow caches `~/.cargo` and `./target` against only the `Cargo.lock` hash, which causes fully cold rebuilds whenever the lockfile changes and keeps stale build artifacts around.

`Swatinem/rust-cache` uses Rust toolchain and workspace-aware keys, restores more effectively across lockfile changes, and prunes old artifacts to keep cache size under control.

Closes #411.

## Validation
This change only updates the GitHub Actions workflow definition. I verified the resulting diff is limited to `.github/workflows/ci.yml` and replaces the manual `actions/cache` block with `Swatinem/rust-cache@v2`.
