### PR TITLE
fix: add Prague (Pectra) spec detection for Ethereum mainnet

### DIFF
--- a/crates/pevm/src/chain/ethereum.rs
+++ b/crates/pevm/src/chain/ethereum.rs
@@ -85,7 +85,10 @@ impl PevmChain for PevmEthereum {
     // TODO: Better error handling & properly test this.
     // TODO: Only Ethereum Mainnet is supported at the moment.
     fn get_block_spec(&self, header: &Header) -> Result<SpecId, Self::BlockSpecError> {
-        Ok(if header.timestamp >= 1710338135 {
+        // Prague (Pectra) activated at timestamp 1746616800 (May 7, 2025 10:05:11 UTC)
+        Ok(if header.timestamp >= 1746616800 {
+            SpecId::PRAGUE
+        } else if header.timestamp >= 1710338135 {
             SpecId::CANCUN
         } else if header.timestamp >= 1681338455 {
             SpecId::SHANGHAI


### PR DESCRIPTION
## Problem

The `get_block_spec` function in `crates/pevm/src/chain/ethereum.rs` only returns `SpecId::CANCUN` for blocks with timestamp >= 1710338135 (March 2024). The Prague (Pectra) hardfork activated on Ethereum mainnet on May 7, 2025 at timestamp 1746616800.

Without this fix, **all post-Prague blocks incorrectly use CANCUN spec**, leading to:
- Invalid transaction execution
- Incorrect receipt generation
- Potential consensus issues

## Fix

Added Prague spec detection with the correct activation timestamp:

```rust
// Prague (Pectra) activated at timestamp 1746616800 (May 7, 2025 10:05:11 UTC)
Ok(if header.timestamp >= 1746616800 {
    SpecId::PRAGUE
} else if header.timestamp >= 1710338135 {
    SpecId::CANCUN
} ...
```

## Verification

- The `build_evm` function already handles Prague correctly (line 124-125)
- The `calculate_receipt_root` function already handles `TxType::Eip7702` (Prague tx type)
- The `get_ethereum_gas_price` function already handles `TxType::Eip7702`
- Code compiles successfully with `cargo check`

## References

- Prague/Pectra activation: https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/prague.md
- Reth Prague config: https://github.com/paradigmxyz/reth/blob/main/crates/primitives/src/chain/spec.rs