### PR TITLE
fix: only retry transient errors in RPC fetch

### DIFF
--- a/crates/pevm/src/storage/rpc.rs
+++ b/crates/pevm/src/storage/rpc.rs
@@ -35,6 +35,15 @@ pub struct RpcStorageError(#[from] pub TransportError);
 
 impl DBErrorMarker for RpcStorageError {}
 
+/// Returns `true` if the error is transient and the request should be retried.
+fn is_retryable(err: &TransportError) -> bool {
+    match err {
+        alloy_json_rpc::RpcError::Transport(kind) => kind.is_retry_err(),
+        alloy_json_rpc::RpcError::NullResp => true,
+        _ => false,
+    }
+}
+
 /// A storage that fetches state data via RPC for execution.
 #[derive(Debug)]
 pub struct RpcStorage<N: Network> {
@@ -84,13 +93,13 @@ impl<N: Network> RpcStorage<N> {
         }
     }
 
-    /// Send a request and retry many times if needed.
-    /// This util is made to avoid error 429 Too Many Requests
+    /// Send a request and retry on transient errors (429, 503, etc).
+    /// Permanent errors are returned immediately without retrying.
     /// <https://en.wikipedia.org/wiki/Exponential_backoff>
-    async fn fetch<T, E, R: IntoFuture<Output = Result<T, E>>>(
+    async fn fetch<T, R: IntoFuture<Output = Result<T, TransportError>>>(
         &self,
         request: impl Fn() -> R,
-    ) -> Result<T, E> {
+    ) -> Result<T, TransportError> {
         const RETRY_LIMIT: usize = 8;
         const INITIAL_DELAY_MILLIS: u64 = 125;
 
@@ -99,12 +108,14 @@ impl<N: Network> RpcStorage<N> {
 
         loop {
             let result = request().await;
-            if lives > 0 && result.is_err() {
-                tokio::time::sleep(delay).await;
-                lives -= 1;
-                delay *= 2;
-            } else {
-                return result;
+            match result {
+                Ok(_) => return result,
+                Err(err) if lives > 0 && is_retryable(&err) => {
+                    tokio::time::sleep(delay).await;
+                    lives -= 1;
+                    delay *= 2;
+                }
+                Err(_) => return result,
             }
         }
     }


### PR DESCRIPTION
## Problem

`RpcStorage::fetch()` retries on **any** error, including permanent failures like:
- Authentication errors (401/403)
- Invalid JSON responses
- Malformed requests

This wastes up to 8 retry attempts with exponential backoff (max ~10s delay) on errors that will never succeed.

## Fix

Added `is_retryable()` helper that checks `TransportErrorKind::is_retry_err()`:
- **Retryable**: 429 Too Many Requests, 503 Service Unavailable, missing batch response
- **Not retryable**: everything else (auth errors, serialization errors, etc.)

The `fetch()` method now returns permanent errors immediately.

## Changes

- `crates/pevm/src/storage/rpc.rs`: Added `is_retryable()` function, changed `fetch()` signature from generic `E` to `TransportError`, added match on error retryability

## Testing

- `cargo check` passes
- Existing RPC tests still work