### PR TITLE
fix: prevent double num_validated increment in scheduler

### DIFF
--- a/crates/pevm/src/scheduler.rs
+++ b/crates/pevm/src/scheduler.rs
@@ -245,6 +245,7 @@ impl Scheduler {
                 }
                 tx.status = IncarnationStatus::Validated;
                 self.num_validated.fetch_add(1, Ordering::Relaxed);
+                return None;
             }
             // Don't need to validate anything if the current validation index is
             // lower or equal -- it will catch up later.


### PR DESCRIPTION
## Bug Description

In `Scheduler::finish_execution`, `num_validated` is incremented **twice** for transactions that don't need validation when their index falls between `min_validation_idx` and `validation_idx`.

### Reproduction Path

When all these conditions are true:
- `min_validation_idx < block_size`
- `tx_idx >= min_validation_idx`
- `tx_idx < validation_idx`
- `!NeedValidation`

The code:
1. Enters the inner `else if` block (line 237)
2. Sets `Validated` and increments `num_validated` (lines 246-247)
3. Falls through to the bottom (line 253-258)
4. Since `!NeedValidation`, sets `Validated` again and increments `num_validated` **again** (lines 256-257)

### Impact

The scheduler thinks more transactions are validated than actually are. This can cause:
- Early termination of block execution
- Incorrect `is_finished()` return value
- Potentially wrong execution results

## Fix

Added `return None;` after the inner block's `num_validated` increment to prevent fall-through to the duplicate increment.

```rust
// Before (inner block falls through)
tx.status = IncarnationStatus::Validated;
self.num_validated.fetch_add(1, Ordering::Relaxed);
// falls through to bottom which increments again

// After (inner block returns early)
tx.status = IncarnationStatus::Validated;
self.num_validated.fetch_add(1, Ordering::Relaxed);
return None;
```