### PR TITLE
fix: use unwrap_or_default for account code in EvmAccount::from

### DIFF
--- a/crates/pevm/src/storage.rs
+++ b/crates/pevm/src/storage.rs
@@ -42,7 +42,7 @@ impl From<Account> for EvmAccount {
             balance: account.info.balance,
             nonce: account.info.nonce,
             code_hash: has_code.then_some(account.info.code_hash),
-            code: has_code.then(|| account.info.code.unwrap().into()),
+            code: has_code.then(|| account.info.code.unwrap_or_default().into()),
             storage: account
                 .storage
                 .into_iter()


### PR DESCRIPTION
## Problem

`storage.rs:45` in `EvmAccount::from(Account)`:
```rust
code: has_code.then(|| account.info.code.unwrap().into()),
```

`has_code` checks if the code hash is not empty, but `account.info.code` can be `None` if the code wasn't loaded yet (e.g., lazy-loaded accounts). This causes a panic.

## Fix

Changed to `unwrap_or_default()`:
```rust
code: has_code.then(|| account.info.code.unwrap_or_default().into()),
```

This returns empty bytecode instead of panicking when code is not loaded.