### PR TITLE
fix: use saturating_sub for genesis block in fetch CLI

### DIFF
--- a/bins/fetch/src/main.rs
+++ b/bins/fetch/src/main.rs
@@ -67,7 +67,7 @@ where
         })?
         .into();
 
-    let storage = RpcStorage::new(provider, spec_id, BlockId::number(block.header.number - 1));
+    let storage = RpcStorage::new(provider, spec_id, BlockId::number(block.header.number.saturating_sub(1)));
 
     // Execute the block and track the pre-state in the RPC storage.
     Pevm::default()


### PR DESCRIPTION
## Problem

`bins/fetch/src/main.rs:70`:
```rust
let storage = RpcStorage::new(provider, spec_id, BlockId::number(block.header.number - 1));
```

For the genesis block (`number=0`), `0u64 - 1` panics in debug or wraps to `u64::MAX` in release, causing incorrect RPC lookups.

## Fix

Changed to `saturating_sub(1)`:
```rust
let storage = RpcStorage::new(provider, spec_id, BlockId::number(block.header.number.saturating_sub(1)));
```

This returns `0` for genesis, which is the correct pre-state block for the first block.