### PR TITLE
fix: remove unsafe get_unchecked in mv_memory record method

### DIFF
--- a/crates/pevm/src/mv_memory.rs
+++ b/crates/pevm/src/mv_memory.rs
@@ -97,9 +97,9 @@ impl MvMemory {
         // Remove old locations that aren't written to anymore.
         let mut last_location_idx = 0;
         while last_location_idx < last_locations.write.len() {
-            let prev_location = unsafe { last_locations.write.get_unchecked(last_location_idx) };
-            if write_set.iter().all(|(l, _)| l != prev_location) {
-                if let Some(mut written_transactions) = self.data.get_mut(prev_location) {
+            let prev_location = last_locations.write[last_location_idx];
+            if write_set.iter().all(|(l, _)| *l != prev_location) {
+                if let Some(mut written_transactions) = self.data.get_mut(&prev_location) {
                     written_transactions.remove(&tx_version.tx_idx);
                 }
                 last_locations.write.swap_remove(last_location_idx);


### PR DESCRIPTION
## Problem

`mv_memory.rs:100-105` uses `unsafe { get_unchecked }` to get a reference to a location, then calls `swap_remove` on the same `Vec`:
```rust
let prev_location = unsafe { last_locations.write.get_unchecked(last_location_idx) };
if write_set.iter().all(|(l, _)| l != prev_location) {
    if let Some(mut written_transactions) = self.data.get_mut(prev_location) {
        written_transactions.remove(&tx_version.tx_idx);
    }
    last_locations.write.swap_remove(last_location_idx);  // invalidates prev_location
}
```

`get_unchecked` creates a `&MemoryLocationHash` borrowing `last_locations.write`. `swap_remove` mutates the same `Vec`, overwriting the slot `prev_location` pointed to. This is unsafe aliasing.

## Fix

Changed to use safe indexing which copies the value:
```rust
let prev_location = last_locations.write[last_location_idx];
if write_set.iter().all(|(l, _)| *l != prev_location) {
    if let Some(mut written_transactions) = self.data.get_mut(&prev_location) {
        written_transactions.remove(&tx_version.tx_idx);
    }
    last_locations.write.swap_remove(last_location_idx);
}
```

This copies the value instead of borrowing, making the code safe without performance impact (u64 copy is trivial).